### PR TITLE
Update for API v1: get_concept_tree now contains information for "actor" (BIMQ 2.9 and higher)

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,13 +9,21 @@ Welcome to the [BIMQ](https://bimq.de) API documentation.
 You can find the full documentation
 on [Postman (external site)](https://documenter.getpostman.com/view/17439674/UVJkAsuk).
 
-### Example responses
+### Changelog and Example Responses
 
-Demo response files for every available request are available as `JSON` files:
+Demo response files for every available request are available as `JSON` files.
 
-| API Version | Examples                | Comments                                                                                                          |
-|-------------|-------------------------|-------------------------------------------------------------------------------------------------------------------|
-| v1          | [Examples](examples/v1) | 2023-08-31 Translations are added for Purposes, Phases and Actors. Phase and Purpose code for purposes are added. |
+#### v1
+
+[Examples](examples/v1)
+
+- 2023-08-31
+    - Translations are added for Purposes, Phases and Actors.
+    - Phase and Purpose code for purposes are added.
+- 2023-10-18 (BIMQ 2.9 and higher)
+    - `get_concept_tree`:
+        - information for `actor` (`code`, `name`, `id`) are added to concepts of type `geometry` and `property`
+        - example JSON file fixed (fields were missing for all concepts: `code`, `unit`, `unit_reference`)
 
 ## Contributing and Contact
 

--- a/examples/v1/Concept_Tree.json
+++ b/examples/v1/Concept_Tree.json
@@ -3,254 +3,36 @@
     "project_id": 1097,
     "project_overview": [
         {
-            "id": 6378245,
-            "name": "TWP Modell",
-            "description": null,
-            "datatype": "Model",
-            "parent_id": null,
-            "template_id": 6378114,
-            "updated_at": "2021-09-29T10:38:44.394+02:00"
-        },
-        {
-            "id": 6378244,
-            "name": "TGA Modell",
-            "description": null,
-            "datatype": "Model",
-            "parent_id": null,
-            "template_id": 6378113,
-            "updated_at": "2021-09-29T10:38:44.394+02:00",
-            "child_concept": [
-                {
-                    "id": 6378253,
-                    "name": "Wärmetauscher",
-                    "description": null,
-                    "datatype": "Type",
-                    "parent_id": 6378244,
-                    "template_id": 6378106,
-                    "updated_at": "2021-09-29T10:38:44.394+02:00",
-                    "map_item": "IfcHeatExchanger.PredefinedType.PLATE",
-                    "map_item_id": 3123914,
-                    "child_concept": [
-                        {
-                            "id": 6378265,
-                            "name": "CKs Eigenschaften (Konzeptname!)",
-                            "description": null,
-                            "datatype": "Group",
-                            "parent_id": 6378253,
-                            "template_id": 6378110,
-                            "updated_at": "2021-09-29T10:38:44.394+02:00",
-                            "map_item": "CKs Eigenschaften",
-                            "map_item_id": 3123981,
-                            "child_concept": [
-                                {
-                                    "id": 6378310,
-                                    "name": "AttributName",
-                                    "description": null,
-                                    "datatype": "Property",
-                                    "parent_id": 6378265,
-                                    "template_id": 6378143,
-                                    "updated_at": "2021-09-29T10:38:44.394+02:00",
-                                    "map_item": "IfcElement Attributes.Name",
-                                    "map_item_id": 3123958
-                                },
-                                {
-                                    "id": 6378311,
-                                    "name": "CKBauteiltyp",
-                                    "description": null,
-                                    "datatype": "Property",
-                                    "parent_id": 6378265,
-                                    "template_id": 6378144,
-                                    "updated_at": "2021-09-29T10:38:44.394+02:00",
-                                    "map_item": "#.CKBauteiltyp",
-                                    "map_item_id": 3124009
-                                },
-                                {
-                                    "id": 6378312,
-                                    "name": "CKsBeschreibung",
-                                    "description": null,
-                                    "datatype": "Property",
-                                    "parent_id": 6378265,
-                                    "template_id": 6378145,
-                                    "updated_at": "2021-09-29T10:38:44.394+02:00",
-                                    "map_item": "IfcElement Attributes.Description",
-                                    "map_item_id": 3123960
-                                },
-                                {
-                                    "id": 6378313,
-                                    "name": "Test Bauteil",
-                                    "description": null,
-                                    "datatype": "Property",
-                                    "parent_id": 6378265,
-                                    "template_id": 6378146,
-                                    "updated_at": "2021-09-29T10:38:44.394+02:00",
-                                    "map_item": "#.Test Bauteil",
-                                    "map_item_id": 3123922
-                                },
-                                {
-                                    "id": 6378344,
-                                    "name": "Raumname",
-                                    "description": null,
-                                    "datatype": "Property",
-                                    "parent_id": 6378265,
-                                    "template_id": 6378149,
-                                    "updated_at": "2021-09-29T10:38:44.394+02:00",
-                                    "map_item": "IfcSpatialElement Attributes.LongName",
-                                    "map_item_id": 3123976
-                                },
-                                {
-                                    "id": 6378345,
-                                    "name": "Raumnummer",
-                                    "description": null,
-                                    "datatype": "Property",
-                                    "parent_id": 6378265,
-                                    "template_id": 6378150,
-                                    "updated_at": "2021-09-29T10:38:44.394+02:00",
-                                    "map_item": "IfcElement Attributes.Name",
-                                    "map_item_id": 3123977
-                                },
-                                {
-                                    "id": 6378346,
-                                    "name": "Testwert",
-                                    "description": null,
-                                    "datatype": "Property",
-                                    "parent_id": 6378265,
-                                    "template_id": 6378154,
-                                    "updated_at": "2021-09-29T10:38:44.394+02:00",
-                                    "map_item": "#.Testwert",
-                                    "map_item_id": 3124007
-                                }
-                            ]
-                        }
-                    ]
-                },
-                {
-                    "id": 6378254,
-                    "name": "WärmetauscherKessel",
-                    "description": null,
-                    "datatype": "Type",
-                    "parent_id": 6378244,
-                    "template_id": 6378107,
-                    "updated_at": "2021-09-29T10:38:44.394+02:00",
-                    "map_item": "IfcHeatExchanger.PredefinedType.USERDEFINED[Kessel]",
-                    "map_item_id": 3123913,
-                    "child_concept": [
-                        {
-                            "id": 6378266,
-                            "name": "CKs Eigenschaften (Konzeptname!)",
-                            "description": null,
-                            "datatype": "Group",
-                            "parent_id": 6378254,
-                            "template_id": 6378110,
-                            "updated_at": "2021-09-29T10:38:44.394+02:00",
-                            "map_item": "CKs Eigenschaften",
-                            "map_item_id": 3123981,
-                            "child_concept": [
-                                {
-                                    "id": 6378314,
-                                    "name": "AttributName",
-                                    "description": null,
-                                    "datatype": "Property",
-                                    "parent_id": 6378266,
-                                    "template_id": 6378143,
-                                    "updated_at": "2021-09-29T10:38:44.394+02:00",
-                                    "map_item": "IfcElement Attributes.Name",
-                                    "map_item_id": 3123958
-                                },
-                                {
-                                    "id": 6378316,
-                                    "name": "CKsBeschreibung",
-                                    "description": null,
-                                    "datatype": "Property",
-                                    "parent_id": 6378266,
-                                    "template_id": 6378145,
-                                    "updated_at": "2021-09-29T10:38:44.394+02:00",
-                                    "map_item": "IfcElement Attributes.Description",
-                                    "map_item_id": 3123960
-                                },
-                                {
-                                    "id": 6378317,
-                                    "name": "Test Bauteil",
-                                    "description": null,
-                                    "datatype": "Property",
-                                    "parent_id": 6378266,
-                                    "template_id": 6378146,
-                                    "updated_at": "2021-09-29T10:38:44.394+02:00",
-                                    "map_item": "#.Test Bauteil",
-                                    "map_item_id": 3123922
-                                },
-                                {
-                                    "id": 6378315,
-                                    "name": "CKBauteiltyp",
-                                    "description": null,
-                                    "datatype": "Property",
-                                    "parent_id": 6378266,
-                                    "template_id": 6378144,
-                                    "updated_at": "2021-09-29T10:38:44.394+02:00",
-                                    "map_item": "#.CKBauteiltyp",
-                                    "map_item_id": 3124009
-                                },
-                                {
-                                    "id": 6378339,
-                                    "name": "Raumname",
-                                    "description": null,
-                                    "datatype": "Property",
-                                    "parent_id": 6378266,
-                                    "template_id": 6378149,
-                                    "updated_at": "2021-09-29T10:38:44.394+02:00",
-                                    "map_item": "IfcSpatialElement Attributes.LongName",
-                                    "map_item_id": 3123976
-                                },
-                                {
-                                    "id": 6378340,
-                                    "name": "Raumnummer",
-                                    "description": null,
-                                    "datatype": "Property",
-                                    "parent_id": 6378266,
-                                    "template_id": 6378150,
-                                    "updated_at": "2021-09-29T10:38:44.394+02:00",
-                                    "map_item": "IfcElement Attributes.Name",
-                                    "map_item_id": 3123977
-                                },
-                                {
-                                    "id": 6378341,
-                                    "name": "Testwert",
-                                    "description": null,
-                                    "datatype": "Property",
-                                    "parent_id": 6378266,
-                                    "template_id": 6378154,
-                                    "updated_at": "2021-09-29T10:38:44.394+02:00",
-                                    "map_item": "#.Testwert",
-                                    "map_item_id": 3124007
-                                }
-                            ]
-                        }
-                    ]
-                }
-            ]
-        },
-        {
             "id": 6378243,
             "name": "CKs Modell",
+            "code": "01",
             "description": null,
             "datatype": "Model",
             "parent_id": null,
             "template_id": 6378100,
             "updated_at": "2021-09-29T10:38:44.394+02:00",
+            "actor": {
+                "id": 5679,
+                "name": "CKPlaner",
+                "code": "OBJ"
+            },
             "child_concept": [
                 {
                     "id": 6378249,
                     "name": "Aussenwand tragend",
+                    "code": "2-01",
                     "description": null,
                     "datatype": "Type",
                     "parent_id": 6378243,
                     "template_id": 6378102,
                     "updated_at": "2021-09-29T10:38:44.394+02:00",
-                    "map_item": "IfcWall.##.##.Pset_WallCommon.IsExternal:True Pset_WallCommon.LoadBearing:True ",
-                    "map_item_id": 3123896,
+                    "map_item_id": 3124433,
+                    "map_item": "IfcWall.##.##.Pset_WallCommon.LoadBearing:True",
                     "child_concept": [
                         {
                             "id": 6378267,
                             "name": "gemeinsame Eigenschaften",
+                            "code": "01",
                             "description": null,
                             "datatype": "Group",
                             "parent_id": 6378249,
@@ -258,41 +40,85 @@
                             "updated_at": "2021-09-29T10:38:44.394+02:00",
                             "child_concept": [
                                 {
+                                    "id": 6380086,
+                                    "name": "Name",
+                                    "code": null,
+                                    "description": null,
+                                    "datatype": "Property",
+                                    "parent_id": 6378267,
+                                    "template_id": 6378153,
+                                    "updated_at": "2021-10-15T09:35:52.127+02:00",
+                                    "unit": "Kennzeichen",
+                                    "unit_reference": "Datatypes.IfcLabel",
+                                    "map_item_id": 3123983,
+                                    "map_item": "#.Name",
+                                    "actor": {
+                                        "id": 5679,
+                                        "name": "CKPlaner",
+                                        "code": "OBJ"
+                                    }
+                                },
+                                {
                                     "id": 6378318,
                                     "name": "Außenbauteil",
+                                    "code": null,
                                     "description": null,
                                     "datatype": "Property",
                                     "parent_id": 6378267,
                                     "template_id": 6378137,
                                     "updated_at": "2021-09-29T10:38:44.394+02:00",
+                                    "unit": "Wahr/Falsch",
+                                    "unit_reference": "Datatypes.IfcBoolean",
+                                    "map_item_id": 3123893,
                                     "map_item": "*.IsExternal",
-                                    "map_item_id": 3123893
+                                    "actor": {
+                                        "id": 5679,
+                                        "name": "CKPlaner",
+                                        "code": "OBJ"
+                                    }
                                 },
                                 {
                                     "id": 6378319,
                                     "name": "Bauteiltyp",
+                                    "code": null,
                                     "description": null,
                                     "datatype": "Property",
                                     "parent_id": 6378267,
                                     "template_id": 6378139,
                                     "updated_at": "2021-09-29T10:38:44.394+02:00",
+                                    "unit": "Identifizierungszeichen",
+                                    "unit_reference": "Datatypes.IfcIdentifier",
+                                    "map_item_id": 3123945,
                                     "map_item": "*.Reference",
-                                    "map_item_id": 3123945
+                                    "actor": {
+                                        "id": 5679,
+                                        "name": "CKPlaner",
+                                        "code": "OBJ"
+                                    }
                                 },
                                 {
                                     "id": 6378320,
                                     "name": "Feuerwiderstandsklasse",
+                                    "code": null,
                                     "description": null,
                                     "datatype": "Property",
                                     "parent_id": 6378267,
                                     "template_id": 6378140,
                                     "updated_at": "2021-09-29T10:38:44.394+02:00",
-                                    "map_item": "*.FireRating",
+                                    "unit": "Kennzeichen",
+                                    "unit_reference": "Datatypes.IfcLabel",
                                     "map_item_id": 3123946,
+                                    "map_item": "*.FireRating",
+                                    "actor": {
+                                        "id": 5679,
+                                        "name": "CKPlaner",
+                                        "code": "OBJ"
+                                    },
                                     "child_concept": [
                                         {
                                             "id": 6378405,
                                             "name": "F30",
+                                            "code": null,
                                             "description": null,
                                             "datatype": "Restriction",
                                             "parent_id": 6378320,
@@ -302,6 +128,7 @@
                                         {
                                             "id": 6378406,
                                             "name": "F60",
+                                            "code": null,
                                             "description": null,
                                             "datatype": "Restriction",
                                             "parent_id": 6378320,
@@ -311,46 +138,253 @@
                                         {
                                             "id": 6378407,
                                             "name": "F90",
+                                            "code": null,
                                             "description": null,
                                             "datatype": "Restriction",
                                             "parent_id": 6378320,
                                             "template_id": 6378213,
                                             "updated_at": "2021-09-29T10:38:44.394+02:00"
+                                        },
+                                        {
+                                            "id": 6519794,
+                                            "name": "70",
+                                            "code": null,
+                                            "description": null,
+                                            "datatype": "Restriction",
+                                            "parent_id": 6378320,
+                                            "template_id": 6378215,
+                                            "updated_at": "2022-08-03T11:10:02.355+02:00"
+                                        },
+                                        {
+                                            "id": 6519795,
+                                            "name": "ABC",
+                                            "code": null,
+                                            "description": null,
+                                            "datatype": "Restriction",
+                                            "parent_id": 6378320,
+                                            "template_id": 6378214,
+                                            "updated_at": "2022-08-03T11:10:02.480+02:00"
+                                        },
+                                        {
+                                            "id": 6519796,
+                                            "name": "F200",
+                                            "code": null,
+                                            "description": null,
+                                            "datatype": "Restriction",
+                                            "parent_id": 6378320,
+                                            "template_id": 6519793,
+                                            "updated_at": "2022-08-03T11:10:02.604+02:00"
                                         }
                                     ]
                                 },
                                 {
                                     "id": 6378321,
                                     "name": "Tragendes Bauteil",
+                                    "code": null,
                                     "description": null,
                                     "datatype": "Property",
                                     "parent_id": 6378267,
                                     "template_id": 6378138,
                                     "updated_at": "2021-09-29T10:38:44.394+02:00",
+                                    "unit": "Wahr/Falsch",
+                                    "unit_reference": "Datatypes.IfcBoolean",
+                                    "map_item_id": 3123900,
                                     "map_item": "*.LoadBearing",
-                                    "map_item_id": 3123900
-                                },
-                                {
-                                    "id": 6380086,
-                                    "name": "Name",
-                                    "description": null,
-                                    "datatype": "Property",
-                                    "parent_id": 6378267,
-                                    "template_id": 6378153,
-                                    "updated_at": "2021-10-15T09:35:52.127+02:00",
-                                    "map_item": "#.Name",
-                                    "map_item_id": 3123983
+                                    "actor": {
+                                        "id": 5679,
+                                        "name": "CKPlaner",
+                                        "code": "OBJ"
+                                    }
                                 },
                                 {
                                     "id": 6378322,
                                     "name": "Wärmedurchgangskoeffizient  (U-Wert)",
+                                    "code": null,
                                     "description": null,
                                     "datatype": "Property",
                                     "parent_id": 6378267,
                                     "template_id": 6378142,
-                                    "updated_at": "2022-06-21T09:46:33.193+02:00",
+                                    "updated_at": "2021-09-29T10:38:44.394+02:00",
+                                    "unit": "Wärmedurchgängigkeit",
+                                    "unit_reference": "Measurements.IfcThermalTransmittanceMeasure",
+                                    "map_item_id": 3123948,
                                     "map_item": "*.ThermalTransmittance",
-                                    "map_item_id": 3123948
+                                    "actor": {
+                                        "id": 5679,
+                                        "name": "CKPlaner",
+                                        "code": "OBJ"
+                                    }
+                                },
+                                {
+                                    "id": 6519806,
+                                    "name": "Spannweite",
+                                    "code": null,
+                                    "description": null,
+                                    "datatype": "Property",
+                                    "parent_id": 6378267,
+                                    "template_id": 6378141,
+                                    "updated_at": "2022-08-03T11:10:33.874+02:00",
+                                    "unit": "Länge (positiv, \u003e0)",
+                                    "unit_reference": "Measurements.IfcPositiveLengthMeasure",
+                                    "map_item_id": 3123947,
+                                    "map_item": "*.Span",
+                                    "actor": {
+                                        "id": 5679,
+                                        "name": "CKPlaner",
+                                        "code": "OBJ"
+                                    }
+                                },
+                                {
+                                    "id": 6519807,
+                                    "name": "Testeigenschaft",
+                                    "code": null,
+                                    "description": null,
+                                    "datatype": "Property",
+                                    "parent_id": 6378267,
+                                    "template_id": 6519792,
+                                    "updated_at": "2022-08-03T11:10:33.988+02:00",
+                                    "unit": "Kennzeichen",
+                                    "unit_reference": "Datatypes.IfcLabel",
+                                    "map_item_id": 3274994,
+                                    "map_item": "#.Testeigenschaft",
+                                    "actor": {
+                                        "id": 5679,
+                                        "name": "CKPlaner",
+                                        "code": "OBJ"
+                                    }
+                                }
+                            ]
+                        },
+                        {
+                            "id": 6860445,
+                            "name": "Geometrie Türen",
+                            "code": "00",
+                            "description": "-",
+                            "datatype": "Group",
+                            "parent_id": 6378249,
+                            "template_id": 6378128,
+                            "updated_at": "2023-04-28T15:15:37.872+02:00",
+                            "child_concept": [
+                                {
+                                    "id": 6860446,
+                                    "name": "LOG 300 - Tür",
+                                    "code": null,
+                                    "description": "Die Türen werden in ihrer genauen Form, Größe, mit sämtlichen Rahmendetails und Öffnungsflügeln modelliert.",
+                                    "datatype": "Geometry",
+                                    "parent_id": 6860445,
+                                    "template_id": 6378175,
+                                    "updated_at": "2023-04-28T15:15:37.910+02:00",
+                                    "actor": {
+                                        "id": 5679,
+                                        "name": "CKPlaner",
+                                        "code": "OBJ"
+                                    }
+                                },
+                                {
+                                    "id": 6860447,
+                                    "name": "LOG 500 - Tür",
+                                    "code": null,
+                                    "description": "Vollständige Modellierung der Türen im konkreten, gebauten Zustand. Sie sind Teil der Objektdokumentation und zur Archivierung des Bestands.",
+                                    "datatype": "Geometry",
+                                    "parent_id": 6860445,
+                                    "template_id": 6378177,
+                                    "updated_at": "2023-04-28T15:15:37.950+02:00",
+                                    "actor": {
+                                        "id": 5679,
+                                        "name": "CKPlaner",
+                                        "code": "OBJ"
+                                    }
+                                },
+                                {
+                                    "id": 6860448,
+                                    "name": "LOG 400 - Tür",
+                                    "code": null,
+                                    "description": "Die Türen enthalten alle Details zur Fertigung. Alle Komponenten, Anschlüsse und die Details für die Vorfertigung und Montage werden detailliert modelliert. Ggf. werden die BIM Objekte der Hersteller verwendet.",
+                                    "datatype": "Geometry",
+                                    "parent_id": 6860445,
+                                    "template_id": 6378176,
+                                    "updated_at": "2023-04-28T15:15:38.013+02:00",
+                                    "actor": {
+                                        "id": 5679,
+                                        "name": "CKPlaner",
+                                        "code": "OBJ"
+                                    }
+                                },
+                                {
+                                    "id": 6860449,
+                                    "name": "LOG 200 - Tür",
+                                    "code": null,
+                                    "description": "Die Türen werden in ihrer ungefähren Form, Größe und Lage modelliert. Die Öffnungsart und Richtung wird angegeben.",
+                                    "datatype": "Geometry",
+                                    "parent_id": 6860445,
+                                    "template_id": 6378174,
+                                    "updated_at": "2023-04-28T15:15:38.113+02:00",
+                                    "actor": {
+                                        "id": 5679,
+                                        "name": "CKPlaner",
+                                        "code": "OBJ"
+                                    }
+                                },
+                                {
+                                    "id": 6860450,
+                                    "name": "LOG 100 - Tür",
+                                    "code": null,
+                                    "description": "Die Position der Türen wird entweder schematisch oder geometrisch mit einer ungefähren, noch flexiblen Geometrie dargestellt. Oft repräsentiert ein Massenmodell das gesamte Bauwerk in dieser Planungsphase.",
+                                    "datatype": "Geometry",
+                                    "parent_id": 6860445,
+                                    "template_id": 6378173,
+                                    "updated_at": "2023-04-28T15:15:38.153+02:00",
+                                    "actor": {
+                                        "id": 5679,
+                                        "name": "CKPlaner",
+                                        "code": "OBJ"
+                                    }
+                                }
+                            ]
+                        },
+                        {
+                            "id": 6860451,
+                            "name": "spezieller Eigenschaftssatz Wände, Türen, Fenster, Fassaden",
+                            "code": "03-01-01",
+                            "description": null,
+                            "datatype": "Group",
+                            "parent_id": 6378249,
+                            "template_id": 6378132,
+                            "updated_at": "2023-04-28T15:15:38.159+02:00",
+                            "child_concept": [
+                                {
+                                    "id": 6860452,
+                                    "name": "Breite Rohbau",
+                                    "code": null,
+                                    "description": "Bauteilbreite Rohbaumaß",
+                                    "datatype": "Property",
+                                    "parent_id": 6860451,
+                                    "template_id": 6378186,
+                                    "updated_at": "2023-04-28T15:15:38.254+02:00",
+                                    "unit": "Länge.m",
+                                    "unit_reference": "Measurements.IfcLengthMeasure.METRE",
+                                    "actor": {
+                                        "id": 5679,
+                                        "name": "CKPlaner",
+                                        "code": "OBJ"
+                                    }
+                                },
+                                {
+                                    "id": 6860453,
+                                    "name": "Höhe Rohbau",
+                                    "code": null,
+                                    "description": "Bauteilhöhe Rohbaumaß",
+                                    "datatype": "Property",
+                                    "parent_id": 6860451,
+                                    "template_id": 6378187,
+                                    "updated_at": "2023-04-28T15:15:38.451+02:00",
+                                    "unit": "Länge.m",
+                                    "unit_reference": "Measurements.IfcLengthMeasure.METRE",
+                                    "actor": {
+                                        "id": 5679,
+                                        "name": "CKPlaner",
+                                        "code": "OBJ"
+                                    }
                                 }
                             ]
                         }
@@ -359,17 +393,19 @@
                 {
                     "id": 6378250,
                     "name": "Balken / Unterzug",
+                    "code": "2-03",
                     "description": null,
                     "datatype": "Type",
                     "parent_id": 6378243,
                     "template_id": 6378109,
                     "updated_at": "2021-09-29T10:38:44.394+02:00",
-                    "map_item": "IfcBeam",
                     "map_item_id": 3123925,
+                    "map_item": "IfcBeam",
                     "child_concept": [
                         {
                             "id": 6378259,
                             "name": "gemeinsame Eigenschaften",
+                            "code": "01",
                             "description": null,
                             "datatype": "Group",
                             "parent_id": 6378250,
@@ -379,39 +415,64 @@
                                 {
                                     "id": 6378285,
                                     "name": "Außenbauteil",
+                                    "code": null,
                                     "description": null,
                                     "datatype": "Property",
                                     "parent_id": 6378259,
                                     "template_id": 6378137,
                                     "updated_at": "2021-09-29T10:38:44.394+02:00",
+                                    "unit": "Wahr/Falsch",
+                                    "unit_reference": "Datatypes.IfcBoolean",
+                                    "map_item_id": 3123893,
                                     "map_item": "*.IsExternal",
-                                    "map_item_id": 3123893
+                                    "actor": {
+                                        "id": 5679,
+                                        "name": "CKPlaner",
+                                        "code": "OBJ"
+                                    }
                                 },
                                 {
                                     "id": 6378286,
                                     "name": "Bauteiltyp",
+                                    "code": null,
                                     "description": null,
                                     "datatype": "Property",
                                     "parent_id": 6378259,
                                     "template_id": 6378139,
                                     "updated_at": "2021-09-29T10:38:44.394+02:00",
+                                    "unit": "Identifizierungszeichen",
+                                    "unit_reference": "Datatypes.IfcIdentifier",
+                                    "map_item_id": 3123945,
                                     "map_item": "*.Reference",
-                                    "map_item_id": 3123945
+                                    "actor": {
+                                        "id": 5679,
+                                        "name": "CKPlaner",
+                                        "code": "OBJ"
+                                    }
                                 },
                                 {
                                     "id": 6378287,
                                     "name": "Feuerwiderstandsklasse",
+                                    "code": null,
                                     "description": null,
                                     "datatype": "Property",
                                     "parent_id": 6378259,
                                     "template_id": 6378140,
                                     "updated_at": "2021-09-29T10:38:44.394+02:00",
-                                    "map_item": "*.FireRating",
+                                    "unit": "Kennzeichen",
+                                    "unit_reference": "Datatypes.IfcLabel",
                                     "map_item_id": 3123946,
+                                    "map_item": "*.FireRating",
+                                    "actor": {
+                                        "id": 5679,
+                                        "name": "CKPlaner",
+                                        "code": "OBJ"
+                                    },
                                     "child_concept": [
                                         {
                                             "id": 6378402,
                                             "name": "F30",
+                                            "code": null,
                                             "description": null,
                                             "datatype": "Restriction",
                                             "parent_id": 6378287,
@@ -421,6 +482,7 @@
                                         {
                                             "id": 6378403,
                                             "name": "F60",
+                                            "code": null,
                                             "description": null,
                                             "datatype": "Restriction",
                                             "parent_id": 6378287,
@@ -430,6 +492,7 @@
                                         {
                                             "id": 6378404,
                                             "name": "F90",
+                                            "code": null,
                                             "description": null,
                                             "datatype": "Restriction",
                                             "parent_id": 6378287,
@@ -439,87 +502,169 @@
                                         {
                                             "id": 6378414,
                                             "name": "70",
+                                            "code": null,
                                             "description": null,
                                             "datatype": "Restriction",
                                             "parent_id": 6378287,
                                             "template_id": 6378215,
                                             "updated_at": "2021-09-29T10:38:44.394+02:00"
+                                        },
+                                        {
+                                            "id": 6519797,
+                                            "name": "ABC",
+                                            "code": null,
+                                            "description": null,
+                                            "datatype": "Restriction",
+                                            "parent_id": 6378287,
+                                            "template_id": 6378214,
+                                            "updated_at": "2022-08-03T11:10:02.829+02:00"
+                                        },
+                                        {
+                                            "id": 6519798,
+                                            "name": "F200",
+                                            "code": null,
+                                            "description": null,
+                                            "datatype": "Restriction",
+                                            "parent_id": 6378287,
+                                            "template_id": 6519793,
+                                            "updated_at": "2022-08-03T11:10:02.833+02:00"
                                         }
                                     ]
                                 },
                                 {
                                     "id": 6378288,
                                     "name": "Spannweite",
+                                    "code": null,
                                     "description": null,
                                     "datatype": "Property",
                                     "parent_id": 6378259,
                                     "template_id": 6378141,
                                     "updated_at": "2021-09-29T10:38:44.394+02:00",
+                                    "unit": "Länge (positiv, \u003e0)",
+                                    "unit_reference": "Measurements.IfcPositiveLengthMeasure",
+                                    "map_item_id": 3123947,
                                     "map_item": "*.Span",
-                                    "map_item_id": 3123947
+                                    "actor": {
+                                        "id": 5679,
+                                        "name": "CKPlaner",
+                                        "code": "OBJ"
+                                    }
                                 },
                                 {
                                     "id": 6378289,
                                     "name": "Tragendes Bauteil",
+                                    "code": null,
                                     "description": null,
                                     "datatype": "Property",
                                     "parent_id": 6378259,
                                     "template_id": 6378138,
                                     "updated_at": "2021-09-29T10:38:44.394+02:00",
+                                    "unit": "Wahr/Falsch",
+                                    "unit_reference": "Datatypes.IfcBoolean",
+                                    "map_item_id": 3123900,
                                     "map_item": "*.LoadBearing",
-                                    "map_item_id": 3123900
+                                    "actor": {
+                                        "id": 5679,
+                                        "name": "CKPlaner",
+                                        "code": "OBJ"
+                                    }
                                 },
                                 {
                                     "id": 6378290,
                                     "name": "Wärmedurchgangskoeffizient  (U-Wert)",
+                                    "code": null,
                                     "description": null,
                                     "datatype": "Property",
                                     "parent_id": 6378259,
                                     "template_id": 6378142,
-                                    "updated_at": "2022-06-21T09:46:33.454+02:00",
+                                    "updated_at": "2021-09-29T10:38:44.394+02:00",
+                                    "unit": "Wärmedurchgängigkeit",
+                                    "unit_reference": "Measurements.IfcThermalTransmittanceMeasure",
+                                    "map_item_id": 3123948,
                                     "map_item": "*.ThermalTransmittance",
-                                    "map_item_id": 3123948
+                                    "actor": {
+                                        "id": 5679,
+                                        "name": "CKPlaner",
+                                        "code": "OBJ"
+                                    }
+                                },
+                                {
+                                    "id": 6519805,
+                                    "name": "Testeigenschaft",
+                                    "code": null,
+                                    "description": null,
+                                    "datatype": "Property",
+                                    "parent_id": 6378259,
+                                    "template_id": 6519792,
+                                    "updated_at": "2022-08-03T11:10:33.638+02:00",
+                                    "unit": "Kennzeichen",
+                                    "unit_reference": "Datatypes.IfcLabel",
+                                    "map_item_id": 3274994,
+                                    "map_item": "#.Testeigenschaft",
+                                    "actor": {
+                                        "id": 5679,
+                                        "name": "CKPlaner",
+                                        "code": "OBJ"
+                                    }
                                 }
                             ]
                         },
                         {
                             "id": 6378263,
                             "name": "CKs Mengen Balken",
+                            "code": "02",
                             "description": null,
                             "datatype": "Group",
                             "parent_id": 6378250,
                             "template_id": 6378111,
                             "updated_at": "2021-09-29T10:38:44.394+02:00",
-                            "map_item": "BaseQuantities",
                             "map_item_id": 3124002,
+                            "map_item": "BaseQuantities",
                             "child_concept": [
                                 {
                                     "id": 6378304,
                                     "name": "Breite",
+                                    "code": null,
                                     "description": "Breite",
                                     "datatype": "Property",
                                     "parent_id": 6378263,
                                     "template_id": 6378147,
                                     "updated_at": "2021-09-29T10:38:44.394+02:00",
+                                    "unit": "Länge",
+                                    "unit_reference": "Measurements.IfcLengthMeasure",
+                                    "map_item_id": 3124051,
                                     "map_item": "BaseQuantities.Width",
-                                    "map_item_id": 3124051
+                                    "actor": {
+                                        "id": 5679,
+                                        "name": "CKPlaner",
+                                        "code": "OBJ"
+                                    }
                                 },
                                 {
                                     "id": 6378305,
                                     "name": "Fläche",
+                                    "code": null,
                                     "description": "Fläche",
                                     "datatype": "Property",
                                     "parent_id": 6378263,
                                     "template_id": 6378148,
                                     "updated_at": "2021-09-29T10:38:44.394+02:00",
-                                    "map_item": "Qto_SlabBaseQuantities.NetArea",
-                                    "map_item_id": 3123971
+                                    "unit": "Fläche",
+                                    "unit_reference": "Measurements.IfcAreaMeasure",
+                                    "map_item_id": 3124000,
+                                    "map_item": "Qto_BeamBaseQuantities.CrossSectionArea",
+                                    "actor": {
+                                        "id": 5679,
+                                        "name": "CKPlaner",
+                                        "code": "OBJ"
+                                    }
                                 }
                             ]
                         },
                         {
                             "id": 6378272,
                             "name": "TEST Properties",
+                            "code": null,
                             "description": null,
                             "datatype": "Group",
                             "parent_id": 6378250,
@@ -529,13 +674,21 @@
                                 {
                                     "id": 6378355,
                                     "name": "BreiteHöhe",
+                                    "code": null,
                                     "description": null,
                                     "datatype": "Property",
                                     "parent_id": 6378272,
                                     "template_id": 6378121,
                                     "updated_at": "2021-09-29T10:38:44.394+02:00",
+                                    "unit": "Kennzeichen",
+                                    "unit_reference": "Datatypes.IfcLabel",
+                                    "map_item_id": 3124169,
                                     "map_item": "#.BreiteHöhe",
-                                    "map_item_id": 3124169
+                                    "actor": {
+                                        "id": 5679,
+                                        "name": "CKPlaner",
+                                        "code": "OBJ"
+                                    }
                                 }
                             ]
                         }
@@ -544,158 +697,380 @@
                 {
                     "id": 6378251,
                     "name": "Geschoßdecke",
+                    "code": "2-04",
                     "description": null,
                     "datatype": "Type",
                     "parent_id": 6378243,
                     "template_id": 6378103,
                     "updated_at": "2021-09-29T10:38:44.394+02:00",
-                    "map_item": "IfcSlab.##.##.Pset_SlabCommon.IsExternal:False ",
                     "map_item_id": 3124436,
+                    "map_item": "IfcSlab.##.##.Pset_SlabCommon.IsExternal:False",
                     "child_concept": [
                         {
                             "id": 6378262,
                             "name": "CKs Eigenschaften (Konzeptname!)",
+                            "code": null,
                             "description": null,
                             "datatype": "Group",
                             "parent_id": 6378251,
                             "template_id": 6378110,
                             "updated_at": "2021-09-29T10:38:44.394+02:00",
-                            "map_item": "CKs Eigenschaften",
                             "map_item_id": 3123981,
+                            "map_item": "CKs Eigenschaften",
                             "child_concept": [
                                 {
                                     "id": 6378299,
                                     "name": "AttributName",
+                                    "code": null,
                                     "description": null,
                                     "datatype": "Property",
                                     "parent_id": 6378262,
                                     "template_id": 6378143,
                                     "updated_at": "2021-09-29T10:38:44.394+02:00",
+                                    "unit": "Kennzeichen",
+                                    "unit_reference": "Datatypes.IfcLabel",
+                                    "map_item_id": 3123958,
                                     "map_item": "IfcElement Attributes.Name",
-                                    "map_item_id": 3123958
+                                    "actor": {
+                                        "id": 5679,
+                                        "name": "CKPlaner",
+                                        "code": "OBJ"
+                                    }
                                 },
                                 {
                                     "id": 6378300,
                                     "name": "CKBauteiltyp",
+                                    "code": null,
                                     "description": null,
                                     "datatype": "Property",
                                     "parent_id": 6378262,
                                     "template_id": 6378144,
                                     "updated_at": "2021-09-29T10:38:44.394+02:00",
+                                    "unit": "Kennzeichen",
+                                    "unit_reference": "Datatypes.IfcLabel",
+                                    "map_item_id": 3124009,
                                     "map_item": "#.CKBauteiltyp",
-                                    "map_item_id": 3124009
+                                    "actor": {
+                                        "id": 5679,
+                                        "name": "CKPlaner",
+                                        "code": "OBJ"
+                                    },
+                                    "child_concept": [
+                                        {
+                                            "id": 6470185,
+                                            "name": "Testwert",
+                                            "code": "1212",
+                                            "description": null,
+                                            "datatype": "Restriction",
+                                            "parent_id": 6378300,
+                                            "template_id": 6470184,
+                                            "updated_at": "2022-06-28T14:05:16.492+02:00"
+                                        }
+                                    ]
                                 },
                                 {
                                     "id": 6378301,
                                     "name": "CKsBeschreibung",
+                                    "code": null,
                                     "description": null,
                                     "datatype": "Property",
                                     "parent_id": 6378262,
                                     "template_id": 6378145,
                                     "updated_at": "2021-09-29T10:38:44.394+02:00",
+                                    "unit": "Kennzeichen",
+                                    "unit_reference": "Datatypes.IfcLabel",
+                                    "map_item_id": 3123960,
                                     "map_item": "IfcElement Attributes.Description",
-                                    "map_item_id": 3123960
+                                    "actor": {
+                                        "id": 5679,
+                                        "name": "CKPlaner",
+                                        "code": "OBJ"
+                                    }
                                 },
                                 {
                                     "id": 6378302,
                                     "name": "Raumname",
+                                    "code": null,
                                     "description": null,
                                     "datatype": "Property",
                                     "parent_id": 6378262,
                                     "template_id": 6378149,
                                     "updated_at": "2021-09-29T10:38:44.394+02:00",
+                                    "unit": "Kennzeichen",
+                                    "unit_reference": "Datatypes.IfcLabel",
+                                    "map_item_id": 3123976,
                                     "map_item": "IfcSpatialElement Attributes.LongName",
-                                    "map_item_id": 3123976
+                                    "actor": {
+                                        "id": 5679,
+                                        "name": "CKPlaner",
+                                        "code": "OBJ"
+                                    }
                                 },
                                 {
                                     "id": 6378303,
                                     "name": "Test Bauteil",
+                                    "code": null,
                                     "description": null,
                                     "datatype": "Property",
                                     "parent_id": 6378262,
                                     "template_id": 6378146,
                                     "updated_at": "2021-09-29T10:38:44.394+02:00",
+                                    "unit": "Wahr/Falsch",
+                                    "unit_reference": "Datatypes.IfcBoolean",
+                                    "map_item_id": 3123922,
                                     "map_item": "#.Test Bauteil",
-                                    "map_item_id": 3123922
+                                    "actor": {
+                                        "id": 5679,
+                                        "name": "CKPlaner",
+                                        "code": "OBJ"
+                                    }
                                 },
                                 {
                                     "id": 6378342,
                                     "name": "Raumnummer",
+                                    "code": null,
                                     "description": null,
                                     "datatype": "Property",
                                     "parent_id": 6378262,
                                     "template_id": 6378150,
                                     "updated_at": "2021-09-29T10:38:44.394+02:00",
+                                    "unit": "Kennzeichen",
+                                    "unit_reference": "Datatypes.IfcLabel",
+                                    "map_item_id": 3123977,
                                     "map_item": "IfcElement Attributes.Name",
-                                    "map_item_id": 3123977
+                                    "actor": {
+                                        "id": 5679,
+                                        "name": "CKPlaner",
+                                        "code": "OBJ"
+                                    }
                                 },
                                 {
                                     "id": 6378343,
                                     "name": "Testwert",
+                                    "code": null,
                                     "description": null,
                                     "datatype": "Property",
                                     "parent_id": 6378262,
                                     "template_id": 6378154,
                                     "updated_at": "2021-09-29T10:38:44.394+02:00",
+                                    "unit": "Länge (nicht-negativ, \u003e=0).m",
+                                    "unit_reference": "Measurements.IfcNonNegativeLengthMeasure.METRE",
+                                    "map_item_id": 3124007,
                                     "map_item": "#.Testwert",
-                                    "map_item_id": 3124007
+                                    "actor": {
+                                        "id": 5679,
+                                        "name": "CKPlaner",
+                                        "code": "OBJ"
+                                    }
                                 }
                             ]
                         },
                         {
                             "id": 6378268,
                             "name": "gemeinsame Eigenschaften",
+                            "code": "01",
                             "description": null,
                             "datatype": "Group",
                             "parent_id": 6378251,
                             "template_id": 6378108,
                             "updated_at": "2021-09-29T10:38:44.394+02:00",
-                            "map_item": "Pset_SlabCommon",
                             "map_item_id": 3124004,
+                            "map_item": "Pset_SlabCommon",
                             "child_concept": [
                                 {
                                     "id": 6378323,
                                     "name": "Außenbauteil",
+                                    "code": null,
                                     "description": null,
                                     "datatype": "Property",
                                     "parent_id": 6378268,
                                     "template_id": 6378137,
                                     "updated_at": "2021-09-29T10:38:44.394+02:00",
+                                    "unit": "Wahr/Falsch",
+                                    "unit_reference": "Datatypes.IfcBoolean",
+                                    "map_item_id": 3123893,
                                     "map_item": "*.IsExternal",
-                                    "map_item_id": 3123893
+                                    "actor": {
+                                        "id": 5679,
+                                        "name": "CKPlaner",
+                                        "code": "OBJ"
+                                    }
                                 },
                                 {
                                     "id": 6378324,
                                     "name": "Bauteiltyp",
+                                    "code": null,
                                     "description": null,
                                     "datatype": "Property",
                                     "parent_id": 6378268,
                                     "template_id": 6378139,
                                     "updated_at": "2021-09-29T10:38:44.394+02:00",
+                                    "unit": "Identifizierungszeichen",
+                                    "unit_reference": "Datatypes.IfcIdentifier",
+                                    "map_item_id": 3123945,
                                     "map_item": "*.Reference",
-                                    "map_item_id": 3123945
+                                    "actor": {
+                                        "id": 5679,
+                                        "name": "CKPlaner",
+                                        "code": "OBJ"
+                                    }
                                 },
                                 {
                                     "id": 6378325,
                                     "name": "Tragendes Bauteil",
+                                    "code": null,
                                     "description": null,
                                     "datatype": "Property",
                                     "parent_id": 6378268,
                                     "template_id": 6378138,
                                     "updated_at": "2021-09-29T10:38:44.394+02:00",
+                                    "unit": "Wahr/Falsch",
+                                    "unit_reference": "Datatypes.IfcBoolean",
+                                    "map_item_id": 3123900,
                                     "map_item": "*.LoadBearing",
-                                    "map_item_id": 3123900
+                                    "actor": {
+                                        "id": 5679,
+                                        "name": "CKPlaner",
+                                        "code": "OBJ"
+                                    }
                                 },
                                 {
                                     "id": 6378326,
                                     "name": "Wärmedurchgangskoeffizient  (U-Wert)",
+                                    "code": null,
                                     "description": null,
                                     "datatype": "Property",
                                     "parent_id": 6378268,
                                     "template_id": 6378142,
-                                    "updated_at": "2022-06-21T09:46:33.467+02:00",
+                                    "updated_at": "2021-09-29T10:38:44.394+02:00",
+                                    "unit": "Wärmedurchgängigkeit",
+                                    "unit_reference": "Measurements.IfcThermalTransmittanceMeasure",
+                                    "map_item_id": 3123948,
                                     "map_item": "*.ThermalTransmittance",
-                                    "map_item_id": 3123948
+                                    "actor": {
+                                        "id": 5679,
+                                        "name": "CKPlaner",
+                                        "code": "OBJ"
+                                    }
+                                },
+                                {
+                                    "id": 6519808,
+                                    "name": "Feuerwiderstandsklasse",
+                                    "code": null,
+                                    "description": null,
+                                    "datatype": "Property",
+                                    "parent_id": 6378268,
+                                    "template_id": 6378140,
+                                    "updated_at": "2022-08-03T11:10:34.104+02:00",
+                                    "unit": "Kennzeichen",
+                                    "unit_reference": "Datatypes.IfcLabel",
+                                    "map_item_id": 3123946,
+                                    "map_item": "*.FireRating",
+                                    "actor": {
+                                        "id": 5679,
+                                        "name": "CKPlaner",
+                                        "code": "OBJ"
+                                    },
+                                    "child_concept": [
+                                        {
+                                            "id": 6519809,
+                                            "name": "70",
+                                            "code": null,
+                                            "description": null,
+                                            "datatype": "Restriction",
+                                            "parent_id": 6519808,
+                                            "template_id": 6378215,
+                                            "updated_at": "2022-08-03T11:10:34.219+02:00"
+                                        },
+                                        {
+                                            "id": 6519810,
+                                            "name": "ABC",
+                                            "code": null,
+                                            "description": null,
+                                            "datatype": "Restriction",
+                                            "parent_id": 6519808,
+                                            "template_id": 6378214,
+                                            "updated_at": "2022-08-03T11:10:34.333+02:00"
+                                        },
+                                        {
+                                            "id": 6519811,
+                                            "name": "F200",
+                                            "code": null,
+                                            "description": null,
+                                            "datatype": "Restriction",
+                                            "parent_id": 6519808,
+                                            "template_id": 6519793,
+                                            "updated_at": "2022-08-03T11:10:34.447+02:00"
+                                        },
+                                        {
+                                            "id": 6519812,
+                                            "name": "F30",
+                                            "code": null,
+                                            "description": null,
+                                            "datatype": "Restriction",
+                                            "parent_id": 6519808,
+                                            "template_id": 6378211,
+                                            "updated_at": "2022-08-03T11:10:34.564+02:00"
+                                        },
+                                        {
+                                            "id": 6519813,
+                                            "name": "F60",
+                                            "code": null,
+                                            "description": null,
+                                            "datatype": "Restriction",
+                                            "parent_id": 6519808,
+                                            "template_id": 6378212,
+                                            "updated_at": "2022-08-03T11:10:34.686+02:00"
+                                        },
+                                        {
+                                            "id": 6519814,
+                                            "name": "F90",
+                                            "code": null,
+                                            "description": null,
+                                            "datatype": "Restriction",
+                                            "parent_id": 6519808,
+                                            "template_id": 6378213,
+                                            "updated_at": "2022-08-03T11:10:34.801+02:00"
+                                        }
+                                    ]
+                                },
+                                {
+                                    "id": 6519815,
+                                    "name": "Spannweite",
+                                    "code": null,
+                                    "description": null,
+                                    "datatype": "Property",
+                                    "parent_id": 6378268,
+                                    "template_id": 6378141,
+                                    "updated_at": "2022-08-03T11:10:34.916+02:00",
+                                    "unit": "Länge (positiv, \u003e0)",
+                                    "unit_reference": "Measurements.IfcPositiveLengthMeasure",
+                                    "map_item_id": 3123947,
+                                    "map_item": "*.Span",
+                                    "actor": {
+                                        "id": 5679,
+                                        "name": "CKPlaner",
+                                        "code": "OBJ"
+                                    }
+                                },
+                                {
+                                    "id": 6519816,
+                                    "name": "Testeigenschaft",
+                                    "code": null,
+                                    "description": null,
+                                    "datatype": "Property",
+                                    "parent_id": 6378268,
+                                    "template_id": 6519792,
+                                    "updated_at": "2022-08-03T11:10:34.923+02:00",
+                                    "unit": "Kennzeichen",
+                                    "unit_reference": "Datatypes.IfcLabel",
+                                    "map_item_id": 3274994,
+                                    "map_item": "#.Testeigenschaft",
+                                    "actor": {
+                                        "id": 5679,
+                                        "name": "CKPlaner",
+                                        "code": "OBJ"
+                                    }
                                 }
                             ]
                         }
@@ -704,107 +1079,166 @@
                 {
                     "id": 6378252,
                     "name": "Innenwand nichttragend",
+                    "code": "2-02",
                     "description": null,
                     "datatype": "Type",
                     "parent_id": 6378243,
                     "template_id": 6378104,
                     "updated_at": "2021-09-29T10:38:44.394+02:00",
-                    "map_item": "IfcWall.##.##.Pset_WallCommon.IsExternal:False Pset_WallCommon.LoadBearing:False ",
-                    "map_item_id": 3124434,
+                    "map_item_id": 3123979,
+                    "map_item": "IfcWall.##.##.Pset_WallCommon.IsExternal:False Pset_WallCommon.LoadBearing:False",
                     "child_concept": [
                         {
                             "id": 6378264,
                             "name": "CKs Eigenschaften (Konzeptname!)",
+                            "code": null,
                             "description": null,
                             "datatype": "Group",
                             "parent_id": 6378252,
                             "template_id": 6378110,
                             "updated_at": "2021-09-29T10:38:44.394+02:00",
-                            "map_item": "CKs Eigenschaften",
                             "map_item_id": 3123981,
+                            "map_item": "CKs Eigenschaften",
                             "child_concept": [
                                 {
                                     "id": 6378306,
                                     "name": "AttributName",
+                                    "code": null,
                                     "description": null,
                                     "datatype": "Property",
                                     "parent_id": 6378264,
                                     "template_id": 6378143,
                                     "updated_at": "2021-09-29T10:38:44.394+02:00",
+                                    "unit": "Kennzeichen",
+                                    "unit_reference": "Datatypes.IfcLabel",
+                                    "map_item_id": 3123958,
                                     "map_item": "IfcElement Attributes.Name",
-                                    "map_item_id": 3123958
+                                    "actor": {
+                                        "id": 5679,
+                                        "name": "CKPlaner",
+                                        "code": "OBJ"
+                                    }
                                 },
                                 {
                                     "id": 6378307,
                                     "name": "CKBauteiltyp",
+                                    "code": null,
                                     "description": null,
                                     "datatype": "Property",
                                     "parent_id": 6378264,
                                     "template_id": 6378144,
                                     "updated_at": "2021-09-29T10:38:44.394+02:00",
+                                    "unit": "Kennzeichen",
+                                    "unit_reference": "Datatypes.IfcLabel",
+                                    "map_item_id": 3124009,
                                     "map_item": "#.CKBauteiltyp",
-                                    "map_item_id": 3124009
+                                    "actor": {
+                                        "id": 5679,
+                                        "name": "CKPlaner",
+                                        "code": "OBJ"
+                                    }
                                 },
                                 {
                                     "id": 6378308,
                                     "name": "CKsBeschreibung",
+                                    "code": null,
                                     "description": null,
                                     "datatype": "Property",
                                     "parent_id": 6378264,
                                     "template_id": 6378145,
                                     "updated_at": "2021-09-29T10:38:44.394+02:00",
+                                    "unit": "Kennzeichen",
+                                    "unit_reference": "Datatypes.IfcLabel",
+                                    "map_item_id": 3123960,
                                     "map_item": "IfcElement Attributes.Description",
-                                    "map_item_id": 3123960
+                                    "actor": {
+                                        "id": 5679,
+                                        "name": "CKPlaner",
+                                        "code": "OBJ"
+                                    }
                                 },
                                 {
                                     "id": 6378309,
                                     "name": "Test Bauteil",
+                                    "code": null,
                                     "description": null,
                                     "datatype": "Property",
                                     "parent_id": 6378264,
                                     "template_id": 6378146,
                                     "updated_at": "2021-09-29T10:38:44.394+02:00",
+                                    "unit": "Wahr/Falsch",
+                                    "unit_reference": "Datatypes.IfcBoolean",
+                                    "map_item_id": 3123922,
                                     "map_item": "#.Test Bauteil",
-                                    "map_item_id": 3123922
+                                    "actor": {
+                                        "id": 5679,
+                                        "name": "CKPlaner",
+                                        "code": "OBJ"
+                                    }
                                 },
                                 {
                                     "id": 6378336,
                                     "name": "Raumname",
+                                    "code": null,
                                     "description": null,
                                     "datatype": "Property",
                                     "parent_id": 6378264,
                                     "template_id": 6378149,
                                     "updated_at": "2021-09-29T10:38:44.394+02:00",
+                                    "unit": "Kennzeichen",
+                                    "unit_reference": "Datatypes.IfcLabel",
+                                    "map_item_id": 3123976,
                                     "map_item": "IfcSpatialElement Attributes.LongName",
-                                    "map_item_id": 3123976
+                                    "actor": {
+                                        "id": 5679,
+                                        "name": "CKPlaner",
+                                        "code": "OBJ"
+                                    }
                                 },
                                 {
                                     "id": 6378337,
                                     "name": "Raumnummer",
+                                    "code": null,
                                     "description": null,
                                     "datatype": "Property",
                                     "parent_id": 6378264,
                                     "template_id": 6378150,
                                     "updated_at": "2021-09-29T10:38:44.394+02:00",
+                                    "unit": "Kennzeichen",
+                                    "unit_reference": "Datatypes.IfcLabel",
+                                    "map_item_id": 3123977,
                                     "map_item": "IfcElement Attributes.Name",
-                                    "map_item_id": 3123977
+                                    "actor": {
+                                        "id": 5679,
+                                        "name": "CKPlaner",
+                                        "code": "OBJ"
+                                    }
                                 },
                                 {
                                     "id": 6378338,
                                     "name": "Testwert",
+                                    "code": null,
                                     "description": null,
                                     "datatype": "Property",
                                     "parent_id": 6378264,
                                     "template_id": 6378154,
                                     "updated_at": "2021-09-29T10:38:44.394+02:00",
+                                    "unit": "Länge (nicht-negativ, \u003e=0).m",
+                                    "unit_reference": "Measurements.IfcNonNegativeLengthMeasure.METRE",
+                                    "map_item_id": 3124007,
                                     "map_item": "#.Testwert",
-                                    "map_item_id": 3124007
+                                    "actor": {
+                                        "id": 5679,
+                                        "name": "CKPlaner",
+                                        "code": "OBJ"
+                                    }
                                 }
                             ]
                         },
                         {
                             "id": 6378269,
                             "name": "gemeinsame Eigenschaften",
+                            "code": "01",
                             "description": null,
                             "datatype": "Group",
                             "parent_id": 6378252,
@@ -812,41 +1246,28 @@
                             "updated_at": "2021-09-29T10:38:44.394+02:00",
                             "child_concept": [
                                 {
-                                    "id": 6378327,
-                                    "name": "Außenbauteil",
-                                    "description": null,
-                                    "datatype": "Property",
-                                    "parent_id": 6378269,
-                                    "template_id": 6378137,
-                                    "updated_at": "2021-09-29T10:38:44.394+02:00",
-                                    "map_item": "*.IsExternal",
-                                    "map_item_id": 3123893
-                                },
-                                {
-                                    "id": 6378328,
-                                    "name": "Bauteiltyp",
-                                    "description": null,
-                                    "datatype": "Property",
-                                    "parent_id": 6378269,
-                                    "template_id": 6378139,
-                                    "updated_at": "2021-09-29T10:38:44.394+02:00",
-                                    "map_item": "*.Reference",
-                                    "map_item_id": 3123945
-                                },
-                                {
                                     "id": 6378329,
                                     "name": "Feuerwiderstandsklasse",
+                                    "code": null,
                                     "description": null,
                                     "datatype": "Property",
                                     "parent_id": 6378269,
                                     "template_id": 6378140,
                                     "updated_at": "2021-09-29T10:38:44.394+02:00",
-                                    "map_item": "*.FireRating",
+                                    "unit": "Kennzeichen",
+                                    "unit_reference": "Datatypes.IfcLabel",
                                     "map_item_id": 3123946,
+                                    "map_item": "*.FireRating",
+                                    "actor": {
+                                        "id": 5679,
+                                        "name": "CKPlaner",
+                                        "code": "OBJ"
+                                    },
                                     "child_concept": [
                                         {
                                             "id": 6378408,
                                             "name": "F30",
+                                            "code": null,
                                             "description": null,
                                             "datatype": "Restriction",
                                             "parent_id": 6378329,
@@ -856,6 +1277,7 @@
                                         {
                                             "id": 6378409,
                                             "name": "F60",
+                                            "code": null,
                                             "description": null,
                                             "datatype": "Restriction",
                                             "parent_id": 6378329,
@@ -865,41 +1287,182 @@
                                         {
                                             "id": 6378410,
                                             "name": "F90",
+                                            "code": null,
                                             "description": null,
                                             "datatype": "Restriction",
                                             "parent_id": 6378329,
                                             "template_id": 6378213,
                                             "updated_at": "2021-09-29T10:38:44.394+02:00"
+                                        },
+                                        {
+                                            "id": 6519800,
+                                            "name": "ABC",
+                                            "code": null,
+                                            "description": null,
+                                            "datatype": "Restriction",
+                                            "parent_id": 6378329,
+                                            "template_id": 6378214,
+                                            "updated_at": "2022-08-03T11:10:02.954+02:00"
+                                        },
+                                        {
+                                            "id": 6519801,
+                                            "name": "F200",
+                                            "code": null,
+                                            "description": null,
+                                            "datatype": "Restriction",
+                                            "parent_id": 6378329,
+                                            "template_id": 6519793,
+                                            "updated_at": "2022-08-03T11:10:02.957+02:00"
+                                        },
+                                        {
+                                            "id": 6519799,
+                                            "name": "70",
+                                            "code": null,
+                                            "description": null,
+                                            "datatype": "Restriction",
+                                            "parent_id": 6378329,
+                                            "template_id": 6378215,
+                                            "updated_at": "2022-08-03T11:10:02.951+02:00"
                                         }
                                     ]
                                 },
                                 {
                                     "id": 6378330,
                                     "name": "Tragendes Bauteil",
+                                    "code": null,
                                     "description": null,
                                     "datatype": "Property",
                                     "parent_id": 6378269,
                                     "template_id": 6378138,
                                     "updated_at": "2021-09-29T10:38:44.394+02:00",
+                                    "unit": "Wahr/Falsch",
+                                    "unit_reference": "Datatypes.IfcBoolean",
+                                    "map_item_id": 3123900,
                                     "map_item": "*.LoadBearing",
-                                    "map_item_id": 3123900
+                                    "actor": {
+                                        "id": 5679,
+                                        "name": "CKPlaner",
+                                        "code": "OBJ"
+                                    }
+                                },
+                                {
+                                    "id": 6378327,
+                                    "name": "Außenbauteil",
+                                    "code": null,
+                                    "description": null,
+                                    "datatype": "Property",
+                                    "parent_id": 6378269,
+                                    "template_id": 6378137,
+                                    "updated_at": "2021-09-29T10:38:44.394+02:00",
+                                    "unit": "Wahr/Falsch",
+                                    "unit_reference": "Datatypes.IfcBoolean",
+                                    "map_item_id": 3123893,
+                                    "map_item": "*.IsExternal",
+                                    "actor": {
+                                        "id": 5679,
+                                        "name": "CKPlaner",
+                                        "code": "OBJ"
+                                    }
+                                },
+                                {
+                                    "id": 6378328,
+                                    "name": "Bauteiltyp",
+                                    "code": null,
+                                    "description": null,
+                                    "datatype": "Property",
+                                    "parent_id": 6378269,
+                                    "template_id": 6378139,
+                                    "updated_at": "2021-09-29T10:38:44.394+02:00",
+                                    "unit": "Identifizierungszeichen",
+                                    "unit_reference": "Datatypes.IfcIdentifier",
+                                    "map_item_id": 3123945,
+                                    "map_item": "*.Reference",
+                                    "actor": {
+                                        "id": 5679,
+                                        "name": "CKPlaner",
+                                        "code": "OBJ"
+                                    }
                                 },
                                 {
                                     "id": 6378331,
                                     "name": "Wärmedurchgangskoeffizient  (U-Wert)",
+                                    "code": null,
                                     "description": null,
                                     "datatype": "Property",
                                     "parent_id": 6378269,
                                     "template_id": 6378142,
-                                    "updated_at": "2022-06-21T09:46:33.459+02:00",
+                                    "updated_at": "2021-09-29T10:38:44.394+02:00",
+                                    "unit": "Wärmedurchgängigkeit",
+                                    "unit_reference": "Measurements.IfcThermalTransmittanceMeasure",
+                                    "map_item_id": 3123948,
                                     "map_item": "*.ThermalTransmittance",
-                                    "map_item_id": 3123948
+                                    "actor": {
+                                        "id": 5679,
+                                        "name": "CKPlaner",
+                                        "code": "OBJ"
+                                    }
+                                },
+                                {
+                                    "id": 6519817,
+                                    "name": "Spannweite",
+                                    "code": null,
+                                    "description": null,
+                                    "datatype": "Property",
+                                    "parent_id": 6378269,
+                                    "template_id": 6378141,
+                                    "updated_at": "2022-08-03T11:10:35.042+02:00",
+                                    "unit": "Länge (positiv, \u003e0)",
+                                    "unit_reference": "Measurements.IfcPositiveLengthMeasure",
+                                    "map_item_id": 3123947,
+                                    "map_item": "*.Span",
+                                    "actor": {
+                                        "id": 5679,
+                                        "name": "CKPlaner",
+                                        "code": "OBJ"
+                                    }
+                                },
+                                {
+                                    "id": 6519818,
+                                    "name": "Testeigenschaft",
+                                    "code": null,
+                                    "description": null,
+                                    "datatype": "Property",
+                                    "parent_id": 6378269,
+                                    "template_id": 6519792,
+                                    "updated_at": "2022-08-03T11:10:35.048+02:00",
+                                    "unit": "Kennzeichen",
+                                    "unit_reference": "Datatypes.IfcLabel",
+                                    "map_item_id": 3274994,
+                                    "map_item": "#.Testeigenschaft",
+                                    "actor": {
+                                        "id": 5679,
+                                        "name": "CKPlaner",
+                                        "code": "OBJ"
+                                    }
+                                },
+                                {
+                                    "id": 6520793,
+                                    "name": "CKBauteiltyp",
+                                    "code": null,
+                                    "description": null,
+                                    "datatype": "Property",
+                                    "parent_id": 6378269,
+                                    "template_id": 6378307,
+                                    "updated_at": "2022-08-03T14:14:31.354+02:00",
+                                    "unit": "Kennzeichen",
+                                    "unit_reference": "Datatypes.IfcLabel",
+                                    "actor": {
+                                        "id": 5679,
+                                        "name": "CKPlaner",
+                                        "code": "OBJ"
+                                    }
                                 }
                             ]
                         },
                         {
                             "id": 6378273,
                             "name": "TEST Properties",
+                            "code": null,
                             "description": null,
                             "datatype": "Group",
                             "parent_id": 6378252,
@@ -909,13 +1472,154 @@
                                 {
                                     "id": 6378356,
                                     "name": "AttTest",
+                                    "code": null,
                                     "description": null,
                                     "datatype": "Property",
                                     "parent_id": 6378273,
                                     "template_id": 6378122,
                                     "updated_at": "2021-09-29T10:38:44.394+02:00",
+                                    "unit": "Kennzeichen",
+                                    "unit_reference": "Datatypes.IfcLabel",
+                                    "map_item_id": 3124175,
                                     "map_item": "#.AttTest",
-                                    "map_item_id": 3124175
+                                    "actor": {
+                                        "id": 5679,
+                                        "name": "CKPlaner",
+                                        "code": "OBJ"
+                                    }
+                                }
+                            ]
+                        },
+                        {
+                            "id": 6860454,
+                            "name": "Geometrie Türen",
+                            "code": "00",
+                            "description": "-",
+                            "datatype": "Group",
+                            "parent_id": 6378252,
+                            "template_id": 6378128,
+                            "updated_at": "2023-04-28T15:15:39.352+02:00",
+                            "child_concept": [
+                                {
+                                    "id": 6860455,
+                                    "name": "LOG 300 - Tür",
+                                    "code": null,
+                                    "description": "Die Türen werden in ihrer genauen Form, Größe, mit sämtlichen Rahmendetails und Öffnungsflügeln modelliert.",
+                                    "datatype": "Geometry",
+                                    "parent_id": 6860454,
+                                    "template_id": 6378175,
+                                    "updated_at": "2023-04-28T15:15:39.407+02:00",
+                                    "actor": {
+                                        "id": 5679,
+                                        "name": "CKPlaner",
+                                        "code": "OBJ"
+                                    }
+                                },
+                                {
+                                    "id": 6860456,
+                                    "name": "LOG 500 - Tür",
+                                    "code": null,
+                                    "description": "Vollständige Modellierung der Türen im konkreten, gebauten Zustand. Sie sind Teil der Objektdokumentation und zur Archivierung des Bestands.",
+                                    "datatype": "Geometry",
+                                    "parent_id": 6860454,
+                                    "template_id": 6378177,
+                                    "updated_at": "2023-04-28T15:15:39.446+02:00",
+                                    "actor": {
+                                        "id": 5679,
+                                        "name": "CKPlaner",
+                                        "code": "OBJ"
+                                    }
+                                },
+                                {
+                                    "id": 6860457,
+                                    "name": "LOG 400 - Tür",
+                                    "code": null,
+                                    "description": "Die Türen enthalten alle Details zur Fertigung. Alle Komponenten, Anschlüsse und die Details für die Vorfertigung und Montage werden detailliert modelliert. Ggf. werden die BIM Objekte der Hersteller verwendet.",
+                                    "datatype": "Geometry",
+                                    "parent_id": 6860454,
+                                    "template_id": 6378176,
+                                    "updated_at": "2023-04-28T15:15:39.506+02:00",
+                                    "actor": {
+                                        "id": 5679,
+                                        "name": "CKPlaner",
+                                        "code": "OBJ"
+                                    }
+                                },
+                                {
+                                    "id": 6860458,
+                                    "name": "LOG 200 - Tür",
+                                    "code": null,
+                                    "description": "Die Türen werden in ihrer ungefähren Form, Größe und Lage modelliert. Die Öffnungsart und Richtung wird angegeben.",
+                                    "datatype": "Geometry",
+                                    "parent_id": 6860454,
+                                    "template_id": 6378174,
+                                    "updated_at": "2023-04-28T15:15:39.609+02:00",
+                                    "actor": {
+                                        "id": 5679,
+                                        "name": "CKPlaner",
+                                        "code": "OBJ"
+                                    }
+                                },
+                                {
+                                    "id": 6860459,
+                                    "name": "LOG 100 - Tür",
+                                    "code": null,
+                                    "description": "Die Position der Türen wird entweder schematisch oder geometrisch mit einer ungefähren, noch flexiblen Geometrie dargestellt. Oft repräsentiert ein Massenmodell das gesamte Bauwerk in dieser Planungsphase.",
+                                    "datatype": "Geometry",
+                                    "parent_id": 6860454,
+                                    "template_id": 6378173,
+                                    "updated_at": "2023-04-28T15:15:39.646+02:00",
+                                    "actor": {
+                                        "id": 5679,
+                                        "name": "CKPlaner",
+                                        "code": "OBJ"
+                                    }
+                                }
+                            ]
+                        },
+                        {
+                            "id": 6860460,
+                            "name": "spezieller Eigenschaftssatz Wände, Türen, Fenster, Fassaden",
+                            "code": "03-01-01",
+                            "description": null,
+                            "datatype": "Group",
+                            "parent_id": 6378252,
+                            "template_id": 6378132,
+                            "updated_at": "2023-04-28T15:15:39.653+02:00",
+                            "child_concept": [
+                                {
+                                    "id": 6860461,
+                                    "name": "Breite Rohbau",
+                                    "code": null,
+                                    "description": "Bauteilbreite Rohbaumaß",
+                                    "datatype": "Property",
+                                    "parent_id": 6860460,
+                                    "template_id": 6378186,
+                                    "updated_at": "2023-04-28T15:15:39.748+02:00",
+                                    "unit": "Länge.m",
+                                    "unit_reference": "Measurements.IfcLengthMeasure.METRE",
+                                    "actor": {
+                                        "id": 5679,
+                                        "name": "CKPlaner",
+                                        "code": "OBJ"
+                                    }
+                                },
+                                {
+                                    "id": 6860462,
+                                    "name": "Höhe Rohbau",
+                                    "code": null,
+                                    "description": "Bauteilhöhe Rohbaumaß",
+                                    "datatype": "Property",
+                                    "parent_id": 6860460,
+                                    "template_id": 6378187,
+                                    "updated_at": "2023-04-28T15:15:39.938+02:00",
+                                    "unit": "Länge.m",
+                                    "unit_reference": "Measurements.IfcLengthMeasure.METRE",
+                                    "actor": {
+                                        "id": 5679,
+                                        "name": "CKPlaner",
+                                        "code": "OBJ"
+                                    }
                                 }
                             ]
                         }
@@ -924,6 +1628,7 @@
                 {
                     "id": 6378256,
                     "name": "Decke",
+                    "code": null,
                     "description": null,
                     "datatype": "Group",
                     "parent_id": 6378243,
@@ -933,107 +1638,159 @@
                         {
                             "id": 6378274,
                             "name": "Tragende_Decken",
+                            "code": null,
                             "description": null,
                             "datatype": "Group",
                             "parent_id": 6378256,
                             "template_id": 6378163,
                             "updated_at": "2021-09-29T10:38:44.394+02:00",
-                            "map_item": "Tragende_Decken",
                             "map_item_id": 3124122,
+                            "map_item": "Tragende_Decken",
                             "child_concept": [
                                 {
                                     "id": 6378357,
                                     "name": "Stahlbetondecke",
+                                    "code": null,
                                     "description": null,
                                     "datatype": "Type",
                                     "parent_id": 6378274,
                                     "template_id": 6378216,
                                     "updated_at": "2021-09-29T10:38:44.394+02:00",
-                                    "map_item": "IfcBuildingElementProxy",
                                     "map_item_id": 3124123,
+                                    "map_item": "IfcBuildingElementProxy",
                                     "child_concept": [
                                         {
                                             "id": 6378415,
                                             "name": "Stahlbeton",
+                                            "code": null,
                                             "description": null,
                                             "datatype": "Group",
                                             "parent_id": 6378357,
                                             "template_id": 6378124,
                                             "updated_at": "2021-09-29T10:38:44.394+02:00",
-                                            "map_item": "Stahlbeton",
                                             "map_item_id": 3124133,
+                                            "map_item": "Stahlbeton",
                                             "child_concept": [
                                                 {
                                                     "id": 6378446,
                                                     "name": "Betonkurzbezeichnung_(B1_B12)",
+                                                    "code": null,
                                                     "description": null,
                                                     "datatype": "Property",
                                                     "parent_id": 6378415,
                                                     "template_id": 6378164,
                                                     "updated_at": "2021-09-29T10:38:44.394+02:00",
+                                                    "unit": "Kennzeichen",
+                                                    "unit_reference": "Datatypes.IfcLabel",
+                                                    "map_item_id": 3124141,
                                                     "map_item": "#.Betonkurzbezeichnung_(B1_B12)",
-                                                    "map_item_id": 3124141
+                                                    "actor": {
+                                                        "id": 5679,
+                                                        "name": "CKPlaner",
+                                                        "code": "OBJ"
+                                                    }
                                                 },
                                                 {
                                                     "id": 6378447,
                                                     "name": "Bewehrungsgrad_kgm3",
+                                                    "code": null,
                                                     "description": null,
                                                     "datatype": "Property",
                                                     "parent_id": 6378415,
                                                     "template_id": 6378165,
                                                     "updated_at": "2021-09-29T10:38:44.394+02:00",
+                                                    "unit": "Kennzeichen",
+                                                    "unit_reference": "Datatypes.IfcLabel",
+                                                    "map_item_id": 3124146,
                                                     "map_item": "#.Bewehrungsgrad_kgm3",
-                                                    "map_item_id": 3124146
+                                                    "actor": {
+                                                        "id": 5679,
+                                                        "name": "CKPlaner",
+                                                        "code": "OBJ"
+                                                    }
                                                 },
                                                 {
                                                     "id": 6378448,
                                                     "name": "Druckfestigkeitsklasse_Beton",
+                                                    "code": null,
                                                     "description": null,
                                                     "datatype": "Property",
                                                     "parent_id": 6378415,
                                                     "template_id": 6378166,
                                                     "updated_at": "2021-09-29T10:38:44.394+02:00",
+                                                    "unit": "Kennzeichen",
+                                                    "unit_reference": "Datatypes.IfcLabel",
+                                                    "map_item_id": 3124151,
                                                     "map_item": "#.Druckfestigkeitsklasse_Beton",
-                                                    "map_item_id": 3124151
+                                                    "actor": {
+                                                        "id": 5679,
+                                                        "name": "CKPlaner",
+                                                        "code": "OBJ"
+                                                    }
                                                 },
                                                 {
                                                     "id": 6378449,
                                                     "name": "Expositionsklasse",
+                                                    "code": null,
                                                     "description": null,
                                                     "datatype": "Property",
                                                     "parent_id": 6378415,
                                                     "template_id": 6378167,
                                                     "updated_at": "2021-09-29T10:38:44.394+02:00",
+                                                    "unit": "Kennzeichen",
+                                                    "unit_reference": "Datatypes.IfcLabel",
+                                                    "map_item_id": 3124156,
                                                     "map_item": "Pset_ConcreteElementGeneral.ExposureClass",
-                                                    "map_item_id": 3124156
+                                                    "actor": {
+                                                        "id": 5679,
+                                                        "name": "CKPlaner",
+                                                        "code": "OBJ"
+                                                    }
                                                 },
                                                 {
                                                     "id": 6378450,
                                                     "name": "Funktion_Stahlbetonarbeiten",
+                                                    "code": null,
                                                     "description": null,
                                                     "datatype": "Property",
                                                     "parent_id": 6378415,
                                                     "template_id": 6378168,
                                                     "updated_at": "2021-09-29T10:38:44.394+02:00",
+                                                    "unit": "Kennzeichen",
+                                                    "unit_reference": "Datatypes.IfcLabel",
+                                                    "map_item_id": 3124161,
                                                     "map_item": "#.Funktion_Stahlbetonarbeiten",
-                                                    "map_item_id": 3124161
+                                                    "actor": {
+                                                        "id": 5679,
+                                                        "name": "CKPlaner",
+                                                        "code": "OBJ"
+                                                    }
                                                 },
                                                 {
                                                     "id": 6378451,
                                                     "name": "Unterstellungshoehe_STB",
+                                                    "code": null,
                                                     "description": null,
                                                     "datatype": "Property",
                                                     "parent_id": 6378415,
                                                     "template_id": 6378169,
                                                     "updated_at": "2021-09-29T10:38:44.394+02:00",
+                                                    "unit": "Kennzeichen",
+                                                    "unit_reference": "Datatypes.IfcLabel",
+                                                    "map_item_id": 3124166,
                                                     "map_item": "#.Unterstellungshoehe_STB",
-                                                    "map_item_id": 3124166
+                                                    "actor": {
+                                                        "id": 5679,
+                                                        "name": "CKPlaner",
+                                                        "code": "OBJ"
+                                                    }
                                                 }
                                             ]
                                         },
                                         {
                                             "id": 6378416,
                                             "name": "Stahlbeton_Halbfertigteil_Fertigteil",
+                                            "code": null,
                                             "description": null,
                                             "datatype": "Group",
                                             "parent_id": 6378357,
@@ -1043,30 +1800,47 @@
                                                 {
                                                     "id": 6378452,
                                                     "name": "Lichte_Weite_Elementdecke",
+                                                    "code": null,
                                                     "description": null,
                                                     "datatype": "Property",
                                                     "parent_id": 6378416,
                                                     "template_id": 6378170,
                                                     "updated_at": "2021-09-29T10:38:44.394+02:00",
+                                                    "unit": "Kennzeichen",
+                                                    "unit_reference": "Datatypes.IfcLabel",
+                                                    "map_item_id": 3124181,
                                                     "map_item": "#.Lichte_Weite_Elementdecke",
-                                                    "map_item_id": 3124181
+                                                    "actor": {
+                                                        "id": 5679,
+                                                        "name": "CKPlaner",
+                                                        "code": "OBJ"
+                                                    }
                                                 },
                                                 {
                                                     "id": 6378453,
                                                     "name": "zulaessige_Auflast_Elementdecke",
+                                                    "code": null,
                                                     "description": null,
                                                     "datatype": "Property",
                                                     "parent_id": 6378416,
                                                     "template_id": 6378171,
                                                     "updated_at": "2021-09-29T10:38:44.394+02:00",
+                                                    "unit": "Kennzeichen",
+                                                    "unit_reference": "Datatypes.IfcLabel",
+                                                    "map_item_id": 3124186,
                                                     "map_item": "#.zulaessige_Auflast_Elementdecke",
-                                                    "map_item_id": 3124186
+                                                    "actor": {
+                                                        "id": 5679,
+                                                        "name": "CKPlaner",
+                                                        "code": "OBJ"
+                                                    }
                                                 }
                                             ]
                                         },
                                         {
                                             "id": 6378417,
                                             "name": "TEST Properties",
+                                            "code": null,
                                             "description": null,
                                             "datatype": "Group",
                                             "parent_id": 6378357,
@@ -1076,13 +1850,21 @@
                                                 {
                                                     "id": 6378454,
                                                     "name": "Test?Test",
+                                                    "code": null,
                                                     "description": null,
                                                     "datatype": "Property",
                                                     "parent_id": 6378417,
                                                     "template_id": 6378126,
                                                     "updated_at": "2021-09-29T10:38:44.394+02:00",
+                                                    "unit": "Kennzeichen",
+                                                    "unit_reference": "Datatypes.IfcLabel",
+                                                    "map_item_id": 3124202,
                                                     "map_item": "#.Test?Test",
-                                                    "map_item_id": 3124202
+                                                    "actor": {
+                                                        "id": 5679,
+                                                        "name": "CKPlaner",
+                                                        "code": "OBJ"
+                                                    }
                                                 }
                                             ]
                                         }
@@ -1091,13 +1873,690 @@
                                 {
                                     "id": 6378358,
                                     "name": "Stahlbetonelementdecke",
+                                    "code": null,
                                     "description": null,
                                     "datatype": "Type",
                                     "parent_id": 6378274,
                                     "template_id": 6378217,
                                     "updated_at": "2021-09-29T10:38:44.394+02:00",
-                                    "map_item": "IfcBuildingElementProxy",
-                                    "map_item_id": 3124127
+                                    "map_item_id": 3124127,
+                                    "map_item": "IfcBuildingElementProxy"
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "id": 6378257,
+                    "name": "Wand",
+                    "code": "1-01",
+                    "description": null,
+                    "datatype": "Type",
+                    "parent_id": 6378243,
+                    "template_id": 6378155,
+                    "updated_at": "2021-09-29T10:38:44.394+02:00",
+                    "map_item_id": 3124067,
+                    "map_item": "IfcWall",
+                    "child_concept": [
+                        {
+                            "id": 6378275,
+                            "name": "gemeinsame Eigenschaften",
+                            "code": "01",
+                            "description": null,
+                            "datatype": "Group",
+                            "parent_id": 6378257,
+                            "template_id": 6378108,
+                            "updated_at": "2021-09-29T10:38:44.394+02:00",
+                            "child_concept": [
+                                {
+                                    "id": 6378359,
+                                    "name": "Außenbauteil",
+                                    "code": null,
+                                    "description": null,
+                                    "datatype": "Property",
+                                    "parent_id": 6378275,
+                                    "template_id": 6378137,
+                                    "updated_at": "2021-09-29T10:38:44.394+02:00",
+                                    "unit": "Wahr/Falsch",
+                                    "unit_reference": "Datatypes.IfcBoolean",
+                                    "map_item_id": 3123893,
+                                    "map_item": "*.IsExternal",
+                                    "actor": {
+                                        "id": 5679,
+                                        "name": "CKPlaner",
+                                        "code": "OBJ"
+                                    }
+                                },
+                                {
+                                    "id": 6378360,
+                                    "name": "Bauteiltyp",
+                                    "code": null,
+                                    "description": null,
+                                    "datatype": "Property",
+                                    "parent_id": 6378275,
+                                    "template_id": 6378139,
+                                    "updated_at": "2021-09-29T10:38:44.394+02:00",
+                                    "unit": "Identifizierungszeichen",
+                                    "unit_reference": "Datatypes.IfcIdentifier",
+                                    "map_item_id": 3123945,
+                                    "map_item": "*.Reference",
+                                    "actor": {
+                                        "id": 5679,
+                                        "name": "CKPlaner",
+                                        "code": "OBJ"
+                                    }
+                                },
+                                {
+                                    "id": 6378361,
+                                    "name": "Feuerwiderstandsklasse",
+                                    "code": null,
+                                    "description": null,
+                                    "datatype": "Property",
+                                    "parent_id": 6378275,
+                                    "template_id": 6378140,
+                                    "updated_at": "2021-09-29T10:38:44.394+02:00",
+                                    "unit": "Kennzeichen",
+                                    "unit_reference": "Datatypes.IfcLabel",
+                                    "map_item_id": 3123946,
+                                    "map_item": "*.FireRating",
+                                    "actor": {
+                                        "id": 5679,
+                                        "name": "CKPlaner",
+                                        "code": "OBJ"
+                                    },
+                                    "child_concept": [
+                                        {
+                                            "id": 6378418,
+                                            "name": "F30",
+                                            "code": null,
+                                            "description": null,
+                                            "datatype": "Restriction",
+                                            "parent_id": 6378361,
+                                            "template_id": 6378211,
+                                            "updated_at": "2021-09-29T10:38:44.394+02:00"
+                                        },
+                                        {
+                                            "id": 6378419,
+                                            "name": "F60",
+                                            "code": null,
+                                            "description": null,
+                                            "datatype": "Restriction",
+                                            "parent_id": 6378361,
+                                            "template_id": 6378212,
+                                            "updated_at": "2021-09-29T10:38:44.394+02:00"
+                                        },
+                                        {
+                                            "id": 6378420,
+                                            "name": "F90",
+                                            "code": null,
+                                            "description": null,
+                                            "datatype": "Restriction",
+                                            "parent_id": 6378361,
+                                            "template_id": 6378213,
+                                            "updated_at": "2021-09-29T10:38:44.394+02:00"
+                                        },
+                                        {
+                                            "id": 6519802,
+                                            "name": "70",
+                                            "code": null,
+                                            "description": null,
+                                            "datatype": "Restriction",
+                                            "parent_id": 6378361,
+                                            "template_id": 6378215,
+                                            "updated_at": "2022-08-03T11:10:03.077+02:00"
+                                        },
+                                        {
+                                            "id": 6519803,
+                                            "name": "ABC",
+                                            "code": null,
+                                            "description": null,
+                                            "datatype": "Restriction",
+                                            "parent_id": 6378361,
+                                            "template_id": 6378214,
+                                            "updated_at": "2022-08-03T11:10:03.081+02:00"
+                                        },
+                                        {
+                                            "id": 6519804,
+                                            "name": "F200",
+                                            "code": null,
+                                            "description": null,
+                                            "datatype": "Restriction",
+                                            "parent_id": 6378361,
+                                            "template_id": 6519793,
+                                            "updated_at": "2022-08-03T11:10:03.086+02:00"
+                                        }
+                                    ]
+                                },
+                                {
+                                    "id": 6378362,
+                                    "name": "Tragendes Bauteil",
+                                    "code": null,
+                                    "description": null,
+                                    "datatype": "Property",
+                                    "parent_id": 6378275,
+                                    "template_id": 6378138,
+                                    "updated_at": "2021-09-29T10:38:44.394+02:00",
+                                    "unit": "Wahr/Falsch",
+                                    "unit_reference": "Datatypes.IfcBoolean",
+                                    "map_item_id": 3123900,
+                                    "map_item": "*.LoadBearing",
+                                    "actor": {
+                                        "id": 5679,
+                                        "name": "CKPlaner",
+                                        "code": "OBJ"
+                                    }
+                                },
+                                {
+                                    "id": 6378363,
+                                    "name": "Wärmedurchgangskoeffizient  (U-Wert)",
+                                    "code": null,
+                                    "description": null,
+                                    "datatype": "Property",
+                                    "parent_id": 6378275,
+                                    "template_id": 6378142,
+                                    "updated_at": "2021-09-29T10:38:44.394+02:00",
+                                    "unit": "Wärmedurchgängigkeit",
+                                    "unit_reference": "Measurements.IfcThermalTransmittanceMeasure",
+                                    "map_item_id": 3123948,
+                                    "map_item": "*.ThermalTransmittance",
+                                    "actor": {
+                                        "id": 5679,
+                                        "name": "CKPlaner",
+                                        "code": "OBJ"
+                                    }
+                                },
+                                {
+                                    "id": 6519819,
+                                    "name": "Spannweite",
+                                    "code": null,
+                                    "description": null,
+                                    "datatype": "Property",
+                                    "parent_id": 6378275,
+                                    "template_id": 6378141,
+                                    "updated_at": "2022-08-03T11:10:35.167+02:00",
+                                    "unit": "Länge (positiv, \u003e0)",
+                                    "unit_reference": "Measurements.IfcPositiveLengthMeasure",
+                                    "map_item_id": 3123947,
+                                    "map_item": "*.Span",
+                                    "actor": {
+                                        "id": 5679,
+                                        "name": "CKPlaner",
+                                        "code": "OBJ"
+                                    }
+                                },
+                                {
+                                    "id": 6519820,
+                                    "name": "Testeigenschaft",
+                                    "code": null,
+                                    "description": null,
+                                    "datatype": "Property",
+                                    "parent_id": 6378275,
+                                    "template_id": 6519792,
+                                    "updated_at": "2022-08-03T11:10:35.173+02:00",
+                                    "unit": "Kennzeichen",
+                                    "unit_reference": "Datatypes.IfcLabel",
+                                    "map_item_id": 3274994,
+                                    "map_item": "#.Testeigenschaft",
+                                    "actor": {
+                                        "id": 5679,
+                                        "name": "CKPlaner",
+                                        "code": "OBJ"
+                                    }
+                                }
+                            ]
+                        },
+                        {
+                            "id": 6860436,
+                            "name": "Geometrie Türen",
+                            "code": "00",
+                            "description": "-",
+                            "datatype": "Group",
+                            "parent_id": 6378257,
+                            "template_id": 6378128,
+                            "updated_at": "2023-04-28T15:15:05.123+02:00",
+                            "child_concept": [
+                                {
+                                    "id": 6860437,
+                                    "name": "LOG 400 - Tür",
+                                    "code": null,
+                                    "description": "Die Türen enthalten alle Details zur Fertigung. Alle Komponenten, Anschlüsse und die Details für die Vorfertigung und Montage werden detailliert modelliert. Ggf. werden die BIM Objekte der Hersteller verwendet.",
+                                    "datatype": "Geometry",
+                                    "parent_id": 6860436,
+                                    "template_id": 6378176,
+                                    "updated_at": "2023-04-28T15:15:05.198+02:00",
+                                    "actor": {
+                                        "id": 5679,
+                                        "name": "CKPlaner",
+                                        "code": "OBJ"
+                                    }
+                                },
+                                {
+                                    "id": 6860438,
+                                    "name": "LOG 200 - Tür",
+                                    "code": null,
+                                    "description": "Die Türen werden in ihrer ungefähren Form, Größe und Lage modelliert. Die Öffnungsart und Richtung wird angegeben.",
+                                    "datatype": "Geometry",
+                                    "parent_id": 6860436,
+                                    "template_id": 6378174,
+                                    "updated_at": "2023-04-28T15:15:05.303+02:00",
+                                    "actor": {
+                                        "id": 5679,
+                                        "name": "CKPlaner",
+                                        "code": "OBJ"
+                                    }
+                                },
+                                {
+                                    "id": 6860439,
+                                    "name": "LOG 500 - Tür",
+                                    "code": null,
+                                    "description": "Vollständige Modellierung der Türen im konkreten, gebauten Zustand. Sie sind Teil der Objektdokumentation und zur Archivierung des Bestands.",
+                                    "datatype": "Geometry",
+                                    "parent_id": 6860436,
+                                    "template_id": 6378177,
+                                    "updated_at": "2023-04-28T15:15:05.340+02:00",
+                                    "actor": {
+                                        "id": 5679,
+                                        "name": "CKPlaner",
+                                        "code": "OBJ"
+                                    }
+                                },
+                                {
+                                    "id": 6860440,
+                                    "name": "LOG 300 - Tür",
+                                    "code": null,
+                                    "description": "Die Türen werden in ihrer genauen Form, Größe, mit sämtlichen Rahmendetails und Öffnungsflügeln modelliert.",
+                                    "datatype": "Geometry",
+                                    "parent_id": 6860436,
+                                    "template_id": 6378175,
+                                    "updated_at": "2023-04-28T15:15:05.375+02:00",
+                                    "actor": {
+                                        "id": 5679,
+                                        "name": "CKPlaner",
+                                        "code": "OBJ"
+                                    }
+                                },
+                                {
+                                    "id": 6860441,
+                                    "name": "LOG 100 - Tür",
+                                    "code": null,
+                                    "description": "Die Position der Türen wird entweder schematisch oder geometrisch mit einer ungefähren, noch flexiblen Geometrie dargestellt. Oft repräsentiert ein Massenmodell das gesamte Bauwerk in dieser Planungsphase.",
+                                    "datatype": "Geometry",
+                                    "parent_id": 6860436,
+                                    "template_id": 6378173,
+                                    "updated_at": "2023-04-28T15:15:05.413+02:00",
+                                    "actor": {
+                                        "id": 5679,
+                                        "name": "CKPlaner",
+                                        "code": "OBJ"
+                                    }
+                                }
+                            ]
+                        },
+                        {
+                            "id": 6860442,
+                            "name": "spezieller Eigenschaftssatz Wände, Türen, Fenster, Fassaden",
+                            "code": "03-01-01",
+                            "description": null,
+                            "datatype": "Group",
+                            "parent_id": 6378257,
+                            "template_id": 6378132,
+                            "updated_at": "2023-04-28T15:15:20.569+02:00",
+                            "child_concept": [
+                                {
+                                    "id": 6860443,
+                                    "name": "Breite Rohbau",
+                                    "code": null,
+                                    "description": "Bauteilbreite Rohbaumaß",
+                                    "datatype": "Property",
+                                    "parent_id": 6860442,
+                                    "template_id": 6378186,
+                                    "updated_at": "2023-04-28T15:15:20.663+02:00",
+                                    "unit": "Länge.m",
+                                    "unit_reference": "Measurements.IfcLengthMeasure.METRE",
+                                    "actor": {
+                                        "id": 5679,
+                                        "name": "CKPlaner",
+                                        "code": "OBJ"
+                                    }
+                                },
+                                {
+                                    "id": 6860444,
+                                    "name": "Höhe Rohbau",
+                                    "code": null,
+                                    "description": "Bauteilhöhe Rohbaumaß",
+                                    "datatype": "Property",
+                                    "parent_id": 6860442,
+                                    "template_id": 6378187,
+                                    "updated_at": "2023-04-28T15:15:20.860+02:00",
+                                    "unit": "Länge.m",
+                                    "unit_reference": "Measurements.IfcLengthMeasure.METRE",
+                                    "actor": {
+                                        "id": 5679,
+                                        "name": "CKPlaner",
+                                        "code": "OBJ"
+                                    }
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "id": 6378253,
+                    "name": "Wärmetauscher",
+                    "code": null,
+                    "description": null,
+                    "datatype": "Type",
+                    "parent_id": 6378243,
+                    "template_id": 6378106,
+                    "updated_at": "2023-04-28T15:13:22.111+02:00",
+                    "map_item_id": 3123914,
+                    "map_item": "IfcHeatExchanger.PredefinedType.PLATE",
+                    "child_concept": [
+                        {
+                            "id": 6378265,
+                            "name": "CKs Eigenschaften (Konzeptname!)",
+                            "code": null,
+                            "description": null,
+                            "datatype": "Group",
+                            "parent_id": 6378253,
+                            "template_id": 6378110,
+                            "updated_at": "2021-09-29T10:38:44.394+02:00",
+                            "map_item_id": 3123981,
+                            "map_item": "CKs Eigenschaften",
+                            "child_concept": [
+                                {
+                                    "id": 6378310,
+                                    "name": "AttributName",
+                                    "code": null,
+                                    "description": null,
+                                    "datatype": "Property",
+                                    "parent_id": 6378265,
+                                    "template_id": 6378143,
+                                    "updated_at": "2021-09-29T10:38:44.394+02:00",
+                                    "unit": "Kennzeichen",
+                                    "unit_reference": "Datatypes.IfcLabel",
+                                    "map_item_id": 3123958,
+                                    "map_item": "IfcElement Attributes.Name",
+                                    "actor": {
+                                        "id": 5680,
+                                        "name": "TGAler",
+                                        "code": "TGA"
+                                    }
+                                },
+                                {
+                                    "id": 6378311,
+                                    "name": "CKBauteiltyp",
+                                    "code": null,
+                                    "description": null,
+                                    "datatype": "Property",
+                                    "parent_id": 6378265,
+                                    "template_id": 6378144,
+                                    "updated_at": "2021-09-29T10:38:44.394+02:00",
+                                    "unit": "Kennzeichen",
+                                    "unit_reference": "Datatypes.IfcLabel",
+                                    "map_item_id": 3124009,
+                                    "map_item": "#.CKBauteiltyp",
+                                    "actor": {
+                                        "id": 5680,
+                                        "name": "TGAler",
+                                        "code": "TGA"
+                                    }
+                                },
+                                {
+                                    "id": 6378312,
+                                    "name": "CKsBeschreibung",
+                                    "code": null,
+                                    "description": null,
+                                    "datatype": "Property",
+                                    "parent_id": 6378265,
+                                    "template_id": 6378145,
+                                    "updated_at": "2021-09-29T10:38:44.394+02:00",
+                                    "unit": "Kennzeichen",
+                                    "unit_reference": "Datatypes.IfcLabel",
+                                    "map_item_id": 3123960,
+                                    "map_item": "IfcElement Attributes.Description",
+                                    "actor": {
+                                        "id": 5680,
+                                        "name": "TGAler",
+                                        "code": "TGA"
+                                    }
+                                },
+                                {
+                                    "id": 6378313,
+                                    "name": "Test Bauteil",
+                                    "code": null,
+                                    "description": null,
+                                    "datatype": "Property",
+                                    "parent_id": 6378265,
+                                    "template_id": 6378146,
+                                    "updated_at": "2021-09-29T10:38:44.394+02:00",
+                                    "unit": "Wahr/Falsch",
+                                    "unit_reference": "Datatypes.IfcBoolean",
+                                    "map_item_id": 3123922,
+                                    "map_item": "#.Test Bauteil",
+                                    "actor": {
+                                        "id": 5680,
+                                        "name": "TGAler",
+                                        "code": "TGA"
+                                    }
+                                },
+                                {
+                                    "id": 6378344,
+                                    "name": "Raumname",
+                                    "code": null,
+                                    "description": null,
+                                    "datatype": "Property",
+                                    "parent_id": 6378265,
+                                    "template_id": 6378149,
+                                    "updated_at": "2021-09-29T10:38:44.394+02:00",
+                                    "unit": "Kennzeichen",
+                                    "unit_reference": "Datatypes.IfcLabel",
+                                    "map_item_id": 3123976,
+                                    "map_item": "IfcSpatialElement Attributes.LongName",
+                                    "actor": {
+                                        "id": 5680,
+                                        "name": "TGAler",
+                                        "code": "TGA"
+                                    }
+                                },
+                                {
+                                    "id": 6378345,
+                                    "name": "Raumnummer",
+                                    "code": null,
+                                    "description": null,
+                                    "datatype": "Property",
+                                    "parent_id": 6378265,
+                                    "template_id": 6378150,
+                                    "updated_at": "2021-09-29T10:38:44.394+02:00",
+                                    "unit": "Kennzeichen",
+                                    "unit_reference": "Datatypes.IfcLabel",
+                                    "map_item_id": 3123977,
+                                    "map_item": "IfcElement Attributes.Name",
+                                    "actor": {
+                                        "id": 5680,
+                                        "name": "TGAler",
+                                        "code": "TGA"
+                                    }
+                                },
+                                {
+                                    "id": 6378346,
+                                    "name": "Testwert",
+                                    "code": null,
+                                    "description": null,
+                                    "datatype": "Property",
+                                    "parent_id": 6378265,
+                                    "template_id": 6378154,
+                                    "updated_at": "2021-09-29T10:38:44.394+02:00",
+                                    "unit": "Länge (nicht-negativ, \u003e=0).m",
+                                    "unit_reference": "Measurements.IfcNonNegativeLengthMeasure.METRE",
+                                    "map_item_id": 3124007,
+                                    "map_item": "#.Testwert",
+                                    "actor": {
+                                        "id": 5680,
+                                        "name": "TGAler",
+                                        "code": "TGA"
+                                    }
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "id": 6378254,
+                    "name": "WärmetauscherKessel",
+                    "code": null,
+                    "description": null,
+                    "datatype": "Type",
+                    "parent_id": 6378243,
+                    "template_id": 6378107,
+                    "updated_at": "2023-04-28T15:13:22.124+02:00",
+                    "map_item_id": 3123913,
+                    "map_item": "IfcHeatExchanger.PredefinedType.USERDEFINED[Kessel]",
+                    "child_concept": [
+                        {
+                            "id": 6378266,
+                            "name": "CKs Eigenschaften (Konzeptname!)",
+                            "code": null,
+                            "description": null,
+                            "datatype": "Group",
+                            "parent_id": 6378254,
+                            "template_id": 6378110,
+                            "updated_at": "2023-04-28T15:13:22.244+02:00",
+                            "map_item_id": 3123981,
+                            "map_item": "CKs Eigenschaften",
+                            "child_concept": [
+                                {
+                                    "id": 6378314,
+                                    "name": "AttributName",
+                                    "code": null,
+                                    "description": null,
+                                    "datatype": "Property",
+                                    "parent_id": 6378266,
+                                    "template_id": 6378143,
+                                    "updated_at": "2023-04-28T15:13:22.244+02:00",
+                                    "unit": "Kennzeichen",
+                                    "unit_reference": "Datatypes.IfcLabel",
+                                    "map_item_id": 3123958,
+                                    "map_item": "IfcElement Attributes.Name",
+                                    "actor": {
+                                        "id": 5680,
+                                        "name": "TGAler",
+                                        "code": "TGA"
+                                    }
+                                },
+                                {
+                                    "id": 6378315,
+                                    "name": "CKBauteiltyp",
+                                    "code": null,
+                                    "description": null,
+                                    "datatype": "Property",
+                                    "parent_id": 6378266,
+                                    "template_id": 6378144,
+                                    "updated_at": "2023-04-28T15:13:22.244+02:00",
+                                    "unit": "Kennzeichen",
+                                    "unit_reference": "Datatypes.IfcLabel",
+                                    "map_item_id": 3124009,
+                                    "map_item": "#.CKBauteiltyp",
+                                    "actor": {
+                                        "id": 5680,
+                                        "name": "TGAler",
+                                        "code": "TGA"
+                                    }
+                                },
+                                {
+                                    "id": 6378340,
+                                    "name": "Raumnummer",
+                                    "code": null,
+                                    "description": null,
+                                    "datatype": "Property",
+                                    "parent_id": 6378266,
+                                    "template_id": 6378150,
+                                    "updated_at": "2023-04-28T15:13:22.244+02:00",
+                                    "unit": "Kennzeichen",
+                                    "unit_reference": "Datatypes.IfcLabel",
+                                    "map_item_id": 3123977,
+                                    "map_item": "IfcElement Attributes.Name",
+                                    "actor": {
+                                        "id": 5680,
+                                        "name": "TGAler",
+                                        "code": "TGA"
+                                    }
+                                },
+                                {
+                                    "id": 6378316,
+                                    "name": "CKsBeschreibung",
+                                    "code": null,
+                                    "description": null,
+                                    "datatype": "Property",
+                                    "parent_id": 6378266,
+                                    "template_id": 6378145,
+                                    "updated_at": "2023-04-28T15:13:22.244+02:00",
+                                    "unit": "Kennzeichen",
+                                    "unit_reference": "Datatypes.IfcLabel",
+                                    "map_item_id": 3123960,
+                                    "map_item": "IfcElement Attributes.Description",
+                                    "actor": {
+                                        "id": 5680,
+                                        "name": "TGAler",
+                                        "code": "TGA"
+                                    }
+                                },
+                                {
+                                    "id": 6378317,
+                                    "name": "Test Bauteil",
+                                    "code": null,
+                                    "description": null,
+                                    "datatype": "Property",
+                                    "parent_id": 6378266,
+                                    "template_id": 6378146,
+                                    "updated_at": "2023-04-28T15:13:22.244+02:00",
+                                    "unit": "Wahr/Falsch",
+                                    "unit_reference": "Datatypes.IfcBoolean",
+                                    "map_item_id": 3123922,
+                                    "map_item": "#.Test Bauteil",
+                                    "actor": {
+                                        "id": 5680,
+                                        "name": "TGAler",
+                                        "code": "TGA"
+                                    }
+                                },
+                                {
+                                    "id": 6378339,
+                                    "name": "Raumname",
+                                    "code": null,
+                                    "description": null,
+                                    "datatype": "Property",
+                                    "parent_id": 6378266,
+                                    "template_id": 6378149,
+                                    "updated_at": "2023-04-28T15:13:22.244+02:00",
+                                    "unit": "Kennzeichen",
+                                    "unit_reference": "Datatypes.IfcLabel",
+                                    "map_item_id": 3123976,
+                                    "map_item": "IfcSpatialElement Attributes.LongName",
+                                    "actor": {
+                                        "id": 5680,
+                                        "name": "TGAler",
+                                        "code": "TGA"
+                                    }
+                                },
+                                {
+                                    "id": 6378341,
+                                    "name": "Testwert",
+                                    "code": null,
+                                    "description": null,
+                                    "datatype": "Property",
+                                    "parent_id": 6378266,
+                                    "template_id": 6378154,
+                                    "updated_at": "2023-04-28T15:13:22.244+02:00",
+                                    "unit": "Länge (nicht-negativ, \u003e=0).m",
+                                    "unit_reference": "Measurements.IfcNonNegativeLengthMeasure.METRE",
+                                    "map_item_id": 3124007,
+                                    "map_item": "#.Testwert",
+                                    "actor": {
+                                        "id": 5680,
+                                        "name": "TGAler",
+                                        "code": "TGA"
+                                    }
                                 }
                             ]
                         }
@@ -1106,15 +2565,19 @@
                 {
                     "id": 6378258,
                     "name": "Tür",
+                    "code": "02-04-01",
                     "description": null,
                     "datatype": "Type",
                     "parent_id": 6378243,
                     "template_id": 6378172,
                     "updated_at": "2021-11-23T10:45:44.046+01:00",
+                    "map_item_id": 3200024,
+                    "map_item": "IfcDoor",
                     "child_concept": [
                         {
                             "id": 6378276,
                             "name": "Geometrie Türen",
+                            "code": "00",
                             "description": "-",
                             "datatype": "Group",
                             "parent_id": 6378258,
@@ -1124,53 +2587,84 @@
                                 {
                                     "id": 6378364,
                                     "name": "LOG 100 - Tür",
+                                    "code": null,
                                     "description": "Die Position der Türen wird entweder schematisch oder geometrisch mit einer ungefähren, noch flexiblen Geometrie dargestellt. Oft repräsentiert ein Massenmodell das gesamte Bauwerk in dieser Planungsphase.",
                                     "datatype": "Geometry",
                                     "parent_id": 6378276,
                                     "template_id": 6378173,
-                                    "updated_at": "2021-09-29T10:38:44.394+02:00"
+                                    "updated_at": "2021-09-29T10:38:44.394+02:00",
+                                    "actor": {
+                                        "id": 5679,
+                                        "name": "CKPlaner",
+                                        "code": "OBJ"
+                                    }
                                 },
                                 {
                                     "id": 6378365,
                                     "name": "LOG 200 - Tür",
+                                    "code": null,
                                     "description": "Die Türen werden in ihrer ungefähren Form, Größe und Lage modelliert. Die Öffnungsart und Richtung wird angegeben.",
                                     "datatype": "Geometry",
                                     "parent_id": 6378276,
                                     "template_id": 6378174,
-                                    "updated_at": "2021-09-29T10:38:44.394+02:00"
+                                    "updated_at": "2021-09-29T10:38:44.394+02:00",
+                                    "actor": {
+                                        "id": 5679,
+                                        "name": "CKPlaner",
+                                        "code": "OBJ"
+                                    }
                                 },
                                 {
                                     "id": 6378366,
                                     "name": "LOG 300 - Tür",
+                                    "code": null,
                                     "description": "Die Türen werden in ihrer genauen Form, Größe, mit sämtlichen Rahmendetails und Öffnungsflügeln modelliert.",
                                     "datatype": "Geometry",
                                     "parent_id": 6378276,
                                     "template_id": 6378175,
-                                    "updated_at": "2021-09-29T10:38:44.394+02:00"
+                                    "updated_at": "2021-09-29T10:38:44.394+02:00",
+                                    "actor": {
+                                        "id": 5679,
+                                        "name": "CKPlaner",
+                                        "code": "OBJ"
+                                    }
                                 },
                                 {
                                     "id": 6378367,
                                     "name": "LOG 400 - Tür",
+                                    "code": null,
                                     "description": "Die Türen enthalten alle Details zur Fertigung. Alle Komponenten, Anschlüsse und die Details für die Vorfertigung und Montage werden detailliert modelliert. Ggf. werden die BIM Objekte der Hersteller verwendet.",
                                     "datatype": "Geometry",
                                     "parent_id": 6378276,
                                     "template_id": 6378176,
-                                    "updated_at": "2021-09-29T10:38:44.394+02:00"
+                                    "updated_at": "2021-09-29T10:38:44.394+02:00",
+                                    "actor": {
+                                        "id": 5679,
+                                        "name": "CKPlaner",
+                                        "code": "OBJ"
+                                    }
                                 },
                                 {
                                     "id": 6378368,
                                     "name": "LOG 500 - Tür",
+                                    "code": null,
                                     "description": "Vollständige Modellierung der Türen im konkreten, gebauten Zustand. Sie sind Teil der Objektdokumentation und zur Archivierung des Bestands.",
                                     "datatype": "Geometry",
                                     "parent_id": 6378276,
                                     "template_id": 6378177,
-                                    "updated_at": "2021-09-29T10:38:44.394+02:00"
+                                    "updated_at": "2021-09-29T10:38:44.394+02:00",
+                                    "actor": {
+                                        "id": 5679,
+                                        "name": "CKPlaner",
+                                        "code": "OBJ"
+                                    }
                                 }
                             ]
                         },
                         {
                             "id": 6378277,
                             "name": "gemeinsame Eigenschaften Bauteile (Modelle)",
+                            "code": "01-01-01",
                             "description": "Kopfdaten für alle Modellelemente",
                             "datatype": "Group",
                             "parent_id": 6378258,
@@ -1179,18 +2673,27 @@
                             "child_concept": [
                                 {
                                     "id": 6378369,
-                                    "name": "Kostengruppe DIN 276",
+                                    "name": "Kostengruppe DIN 276-+",
+                                    "code": "03",
                                     "description": null,
                                     "datatype": "Property",
                                     "parent_id": 6378277,
                                     "template_id": 6378178,
-                                    "updated_at": "2021-09-29T10:38:44.394+02:00"
+                                    "updated_at": "2022-08-03T11:01:08.710+02:00",
+                                    "unit": "Kennzeichen",
+                                    "unit_reference": "Datatypes.IfcLabel",
+                                    "actor": {
+                                        "id": 5679,
+                                        "name": "CKPlaner",
+                                        "code": "OBJ"
+                                    }
                                 }
                             ]
                         },
                         {
                             "id": 6378278,
                             "name": "gemeinsame Eigenschaften Bauteile (IFC)",
+                            "code": "01-01-02",
                             "description": "Kopfdaten für alle Modellelemente nach IFC",
                             "datatype": "Group",
                             "parent_id": 6378258,
@@ -1200,35 +2703,60 @@
                                 {
                                     "id": 6378370,
                                     "name": "Bauteilname",
+                                    "code": "01",
                                     "description": null,
                                     "datatype": "Property",
                                     "parent_id": 6378278,
                                     "template_id": 6378179,
-                                    "updated_at": "2021-09-29T10:38:44.394+02:00"
+                                    "updated_at": "2021-09-29T10:38:44.394+02:00",
+                                    "unit": "Kennzeichen",
+                                    "unit_reference": "Datatypes.IfcLabel",
+                                    "actor": {
+                                        "id": 5679,
+                                        "name": "CKPlaner",
+                                        "code": "OBJ"
+                                    }
                                 },
                                 {
                                     "id": 6378371,
                                     "name": "Typ",
+                                    "code": "02",
                                     "description": null,
                                     "datatype": "Property",
                                     "parent_id": 6378278,
                                     "template_id": 6378180,
-                                    "updated_at": "2021-09-29T10:38:44.394+02:00"
+                                    "updated_at": "2021-09-29T10:38:44.394+02:00",
+                                    "unit": "Kennzeichen",
+                                    "unit_reference": "Datatypes.IfcLabel",
+                                    "actor": {
+                                        "id": 5679,
+                                        "name": "CKPlaner",
+                                        "code": "OBJ"
+                                    }
                                 },
                                 {
                                     "id": 6378372,
                                     "name": "Beschreibung",
+                                    "code": "03",
                                     "description": null,
                                     "datatype": "Property",
                                     "parent_id": 6378278,
                                     "template_id": 6378181,
-                                    "updated_at": "2021-09-29T10:38:44.394+02:00"
+                                    "updated_at": "2021-09-29T10:38:44.394+02:00",
+                                    "unit": "Kennzeichen",
+                                    "unit_reference": "Datatypes.IfcLabel",
+                                    "actor": {
+                                        "id": 5679,
+                                        "name": "CKPlaner",
+                                        "code": "OBJ"
+                                    }
                                 }
                             ]
                         },
                         {
                             "id": 6378279,
                             "name": "gemeinsame Eigenschaften (IFC)",
+                            "code": "01-02",
                             "description": "Gemeinsame IFC Eigenschaften",
                             "datatype": "Group",
                             "parent_id": 6378258,
@@ -1238,15 +2766,24 @@
                                 {
                                     "id": 6378373,
                                     "name": "Feuerwiderstandsklasse",
+                                    "code": null,
                                     "description": "Feuerwiderstandsklasse gemäß der nationalen oder regionalen Brandschutzverordnung.",
                                     "datatype": "Property",
                                     "parent_id": 6378279,
                                     "template_id": 6378182,
                                     "updated_at": "2021-09-29T10:38:44.394+02:00",
+                                    "unit": "Kennzeichen",
+                                    "unit_reference": "Datatypes.IfcLabel",
+                                    "actor": {
+                                        "id": 5679,
+                                        "name": "CKPlaner",
+                                        "code": "OBJ"
+                                    },
                                     "child_concept": [
                                         {
                                             "id": 6378422,
                                             "name": "F60",
+                                            "code": null,
                                             "description": null,
                                             "datatype": "Restriction",
                                             "parent_id": 6378373,
@@ -1256,6 +2793,7 @@
                                         {
                                             "id": 6378423,
                                             "name": "F90",
+                                            "code": null,
                                             "description": null,
                                             "datatype": "Restriction",
                                             "parent_id": 6378373,
@@ -1265,6 +2803,7 @@
                                         {
                                             "id": 6378421,
                                             "name": "F30",
+                                            "code": null,
                                             "description": null,
                                             "datatype": "Restriction",
                                             "parent_id": 6378373,
@@ -1276,24 +2815,51 @@
                                 {
                                     "id": 6378374,
                                     "name": "Rauchschutz",
+                                    "code": null,
                                     "description": "Rauchschutz nach DIN 18095 / EN 16034-3",
                                     "datatype": "Property",
                                     "parent_id": 6378279,
                                     "template_id": 6378183,
-                                    "updated_at": "2021-09-29T10:38:44.394+02:00"
+                                    "updated_at": "2021-09-29T10:38:44.394+02:00",
+                                    "unit": "Wahr/Falsch",
+                                    "unit_reference": "Datatypes.IfcBoolean",
+                                    "actor": {
+                                        "id": 5679,
+                                        "name": "CKPlaner",
+                                        "code": "OBJ"
+                                    }
                                 },
                                 {
                                     "id": 6378375,
                                     "name": "Schallschutzklasse",
+                                    "code": null,
                                     "description": "Schallschutzklasse gemäß der nationalen oder regionalen Schallschutzverordnung DIN 4109",
                                     "datatype": "Property",
                                     "parent_id": 6378279,
                                     "template_id": 6378184,
                                     "updated_at": "2021-09-29T10:38:44.394+02:00",
+                                    "unit": "Kennzeichen",
+                                    "unit_reference": "Datatypes.IfcLabel",
+                                    "actor": {
+                                        "id": 5679,
+                                        "name": "CKPlaner",
+                                        "code": "OBJ"
+                                    },
                                     "child_concept": [
+                                        {
+                                            "id": 6378424,
+                                            "name": "1",
+                                            "code": "00",
+                                            "description": null,
+                                            "datatype": "Restriction",
+                                            "parent_id": 6378375,
+                                            "template_id": 6378221,
+                                            "updated_at": "2021-09-29T10:38:44.394+02:00"
+                                        },
                                         {
                                             "id": 6378425,
                                             "name": "2",
+                                            "code": "01",
                                             "description": null,
                                             "datatype": "Restriction",
                                             "parent_id": 6378375,
@@ -1303,6 +2869,7 @@
                                         {
                                             "id": 6378426,
                                             "name": "3",
+                                            "code": "02",
                                             "description": null,
                                             "datatype": "Restriction",
                                             "parent_id": 6378375,
@@ -1312,6 +2879,7 @@
                                         {
                                             "id": 6378427,
                                             "name": "4",
+                                            "code": "03",
                                             "description": null,
                                             "datatype": "Restriction",
                                             "parent_id": 6378375,
@@ -1321,6 +2889,7 @@
                                         {
                                             "id": 6378428,
                                             "name": "5",
+                                            "code": "04",
                                             "description": null,
                                             "datatype": "Restriction",
                                             "parent_id": 6378375,
@@ -1330,19 +2899,11 @@
                                         {
                                             "id": 6378429,
                                             "name": "6",
+                                            "code": "05",
                                             "description": null,
                                             "datatype": "Restriction",
                                             "parent_id": 6378375,
                                             "template_id": 6378226,
-                                            "updated_at": "2021-09-29T10:38:44.394+02:00"
-                                        },
-                                        {
-                                            "id": 6378424,
-                                            "name": "1",
-                                            "description": null,
-                                            "datatype": "Restriction",
-                                            "parent_id": 6378375,
-                                            "template_id": 6378221,
                                             "updated_at": "2021-09-29T10:38:44.394+02:00"
                                         }
                                     ]
@@ -1350,17 +2911,26 @@
                                 {
                                     "id": 6378376,
                                     "name": "Wärmedurchgangskoeffizient (U-Wert)",
+                                    "code": null,
                                     "description": "Wärmedurchgangskoeffizient (U-Wert) der Materialschichten. Hier der Gesamtwärmedurchgangskoeffizient der Bekleidung (für alle Schichten).",
                                     "datatype": "Property",
                                     "parent_id": 6378279,
                                     "template_id": 6378185,
-                                    "updated_at": "2021-09-29T10:38:44.394+02:00"
+                                    "updated_at": "2021-09-29T10:38:44.394+02:00",
+                                    "unit": "Wärmedurchgängigkeit",
+                                    "unit_reference": "Measurements.IfcThermalTransmittanceMeasure",
+                                    "actor": {
+                                        "id": 5679,
+                                        "name": "CKPlaner",
+                                        "code": "OBJ"
+                                    }
                                 }
                             ]
                         },
                         {
                             "id": 6378280,
                             "name": "spezieller Eigenschaftssatz Wände, Türen, Fenster, Fassaden",
+                            "code": "03-01-01",
                             "description": null,
                             "datatype": "Group",
                             "parent_id": 6378258,
@@ -1370,26 +2940,43 @@
                                 {
                                     "id": 6378377,
                                     "name": "Breite Rohbau",
+                                    "code": null,
                                     "description": "Bauteilbreite Rohbaumaß",
                                     "datatype": "Property",
                                     "parent_id": 6378280,
                                     "template_id": 6378186,
-                                    "updated_at": "2021-09-29T10:38:44.394+02:00"
+                                    "updated_at": "2021-09-29T10:38:44.394+02:00",
+                                    "unit": "Länge.m",
+                                    "unit_reference": "Measurements.IfcLengthMeasure.METRE",
+                                    "actor": {
+                                        "id": 5679,
+                                        "name": "CKPlaner",
+                                        "code": "OBJ"
+                                    }
                                 },
                                 {
                                     "id": 6378378,
                                     "name": "Höhe Rohbau",
+                                    "code": null,
                                     "description": "Bauteilhöhe Rohbaumaß",
                                     "datatype": "Property",
                                     "parent_id": 6378280,
                                     "template_id": 6378187,
-                                    "updated_at": "2021-09-29T10:38:44.394+02:00"
+                                    "updated_at": "2021-09-29T10:38:44.394+02:00",
+                                    "unit": "Länge.m",
+                                    "unit_reference": "Measurements.IfcLengthMeasure.METRE",
+                                    "actor": {
+                                        "id": 5679,
+                                        "name": "CKPlaner",
+                                        "code": "OBJ"
+                                    }
                                 }
                             ]
                         },
                         {
                             "id": 6378281,
                             "name": "spezieller Eigenschaftssatz Türen (Modelle)",
+                            "code": "03-05-01",
                             "description": null,
                             "datatype": "Group",
                             "parent_id": 6378258,
@@ -1397,71 +2984,26 @@
                             "updated_at": "2021-09-29T10:38:44.394+02:00",
                             "child_concept": [
                                 {
-                                    "id": 6378387,
-                                    "name": "Türhöhe Rohbaumaß",
-                                    "description": "Türliste, Detailangabe",
-                                    "datatype": "Property",
-                                    "parent_id": 6378281,
-                                    "template_id": 6378196,
-                                    "updated_at": "2021-09-29T10:38:44.394+02:00"
-                                },
-                                {
-                                    "id": 6378388,
-                                    "name": "Türschliesser",
-                                    "description": "Ausstattung von Türen: Türschliesser. ",
-                                    "datatype": "Property",
-                                    "parent_id": 6378281,
-                                    "template_id": 6378197,
-                                    "updated_at": "2021-09-29T10:38:44.394+02:00"
-                                },
-                                {
-                                    "id": 6378389,
-                                    "name": "Zargenart",
-                                    "description": "Türliste, Detailangabe",
-                                    "datatype": "Property",
-                                    "parent_id": 6378281,
-                                    "template_id": 6378198,
-                                    "updated_at": "2021-09-29T10:38:44.394+02:00"
-                                },
-                                {
-                                    "id": 6378390,
-                                    "name": "Zargenstärke",
-                                    "description": "Türliste, Detailangabe",
-                                    "datatype": "Property",
-                                    "parent_id": 6378281,
-                                    "template_id": 6378199,
-                                    "updated_at": "2021-09-29T10:38:44.394+02:00"
-                                },
-                                {
-                                    "id": 6378391,
-                                    "name": "Zargentiefe",
-                                    "description": "Türliste, Detailangabe",
-                                    "datatype": "Property",
-                                    "parent_id": 6378281,
-                                    "template_id": 6378200,
-                                    "updated_at": "2021-09-29T10:38:44.394+02:00"
-                                },
-                                {
-                                    "id": 6378392,
-                                    "name": "Zulassungsnummer",
-                                    "description": "Türliste, Detailangabe",
-                                    "datatype": "Property",
-                                    "parent_id": 6378281,
-                                    "template_id": 6378201,
-                                    "updated_at": "2021-09-29T10:38:44.394+02:00"
-                                },
-                                {
                                     "id": 6378379,
                                     "name": "Art der Tür",
+                                    "code": null,
                                     "description": null,
                                     "datatype": "Property",
                                     "parent_id": 6378281,
                                     "template_id": 6378188,
                                     "updated_at": "2021-09-29T10:38:44.394+02:00",
+                                    "unit": "Kennzeichen",
+                                    "unit_reference": "Datatypes.IfcLabel",
+                                    "actor": {
+                                        "id": 5679,
+                                        "name": "CKPlaner",
+                                        "code": "OBJ"
+                                    },
                                     "child_concept": [
                                         {
                                             "id": 6378433,
                                             "name": "Wohnungstür",
+                                            "code": null,
                                             "description": null,
                                             "datatype": "Restriction",
                                             "parent_id": 6378379,
@@ -1471,6 +3013,7 @@
                                         {
                                             "id": 6378430,
                                             "name": "Fenster/Balkontür",
+                                            "code": null,
                                             "description": null,
                                             "datatype": "Restriction",
                                             "parent_id": 6378379,
@@ -1480,6 +3023,7 @@
                                         {
                                             "id": 6378431,
                                             "name": "Hauseingangstür",
+                                            "code": null,
                                             "description": null,
                                             "datatype": "Restriction",
                                             "parent_id": 6378379,
@@ -1489,6 +3033,7 @@
                                         {
                                             "id": 6378432,
                                             "name": "Technische Türen",
+                                            "code": null,
                                             "description": "z.B. Lift, Schaltschrank,..",
                                             "datatype": "Restriction",
                                             "parent_id": 6378379,
@@ -1498,6 +3043,7 @@
                                         {
                                             "id": 6378434,
                                             "name": "Zimmertür",
+                                            "code": null,
                                             "description": null,
                                             "datatype": "Restriction",
                                             "parent_id": 6378379,
@@ -1509,15 +3055,24 @@
                                 {
                                     "id": 6378380,
                                     "name": "Bodenschwelle",
+                                    "code": null,
                                     "description": "Eigenschaft Bodenschwelle",
                                     "datatype": "Property",
                                     "parent_id": 6378281,
                                     "template_id": 6378189,
                                     "updated_at": "2021-09-29T10:38:44.394+02:00",
+                                    "unit": "Kennzeichen",
+                                    "unit_reference": "Datatypes.IfcLabel",
+                                    "actor": {
+                                        "id": 5679,
+                                        "name": "CKPlaner",
+                                        "code": "OBJ"
+                                    },
                                     "child_concept": [
                                         {
                                             "id": 6378436,
                                             "name": "mit Stufe",
+                                            "code": "01",
                                             "description": null,
                                             "datatype": "Restriction",
                                             "parent_id": 6378380,
@@ -1527,6 +3082,7 @@
                                         {
                                             "id": 6378435,
                                             "name": "stufenlos",
+                                            "code": "00",
                                             "description": null,
                                             "datatype": "Restriction",
                                             "parent_id": 6378380,
@@ -1538,62 +3094,213 @@
                                 {
                                     "id": 6378381,
                                     "name": "Durchgangsbreite",
+                                    "code": null,
                                     "description": "Durchgangsbreite von Türen",
                                     "datatype": "Property",
                                     "parent_id": 6378281,
                                     "template_id": 6378190,
-                                    "updated_at": "2021-09-29T10:38:44.394+02:00"
+                                    "updated_at": "2021-09-29T10:38:44.394+02:00",
+                                    "unit": "Länge.m",
+                                    "unit_reference": "Measurements.IfcLengthMeasure.METRE",
+                                    "actor": {
+                                        "id": 5679,
+                                        "name": "CKPlaner",
+                                        "code": "OBJ"
+                                    }
                                 },
                                 {
                                     "id": 6378382,
                                     "name": "Durchgangshöhe",
+                                    "code": null,
                                     "description": "Türliste, Detailangabe",
                                     "datatype": "Property",
                                     "parent_id": 6378281,
                                     "template_id": 6378191,
-                                    "updated_at": "2021-09-29T10:38:44.394+02:00"
+                                    "updated_at": "2021-09-29T10:38:44.394+02:00",
+                                    "unit": "Länge.m",
+                                    "unit_reference": "Measurements.IfcLengthMeasure.METRE",
+                                    "actor": {
+                                        "id": 5679,
+                                        "name": "CKPlaner",
+                                        "code": "OBJ"
+                                    }
                                 },
                                 {
                                     "id": 6378383,
                                     "name": "Fluchtweg Aussentür",
+                                    "code": null,
                                     "description": "nicht abschliessbar, mit Notausgangsverschluss. Zu klären ist, wie die Türe trotz Fluchtfunktion abgeschlossen werden kann.",
                                     "datatype": "Property",
                                     "parent_id": 6378281,
                                     "template_id": 6378192,
-                                    "updated_at": "2021-09-29T10:38:44.394+02:00"
+                                    "updated_at": "2021-09-29T10:38:44.394+02:00",
+                                    "unit": "Kennzeichen",
+                                    "unit_reference": "Datatypes.IfcLabel",
+                                    "actor": {
+                                        "id": 5679,
+                                        "name": "CKPlaner",
+                                        "code": "OBJ"
+                                    }
                                 },
                                 {
                                     "id": 6378384,
                                     "name": "Obentürschließer",
+                                    "code": null,
                                     "description": null,
                                     "datatype": "Property",
                                     "parent_id": 6378281,
                                     "template_id": 6378193,
-                                    "updated_at": "2021-09-29T10:38:44.394+02:00"
+                                    "updated_at": "2021-09-29T10:38:44.394+02:00",
+                                    "unit": "Wahr/Falsch",
+                                    "unit_reference": "Datatypes.IfcBoolean",
+                                    "actor": {
+                                        "id": 5679,
+                                        "name": "CKPlaner",
+                                        "code": "OBJ"
+                                    }
                                 },
                                 {
                                     "id": 6378385,
                                     "name": "Offenhaltung",
+                                    "code": null,
                                     "description": null,
                                     "datatype": "Property",
                                     "parent_id": 6378281,
                                     "template_id": 6378194,
-                                    "updated_at": "2021-09-29T10:38:44.394+02:00"
+                                    "updated_at": "2021-09-29T10:38:44.394+02:00",
+                                    "unit": "Wahr/Falsch",
+                                    "unit_reference": "Datatypes.IfcBoolean",
+                                    "actor": {
+                                        "id": 5679,
+                                        "name": "CKPlaner",
+                                        "code": "OBJ"
+                                    }
                                 },
                                 {
                                     "id": 6378386,
                                     "name": "Türblattstärke",
+                                    "code": null,
                                     "description": "Türliste, Detailangabe",
                                     "datatype": "Property",
                                     "parent_id": 6378281,
                                     "template_id": 6378195,
-                                    "updated_at": "2021-09-29T10:38:44.394+02:00"
+                                    "updated_at": "2021-09-29T10:38:44.394+02:00",
+                                    "unit": "Länge.m",
+                                    "unit_reference": "Measurements.IfcLengthMeasure.METRE",
+                                    "actor": {
+                                        "id": 5679,
+                                        "name": "CKPlaner",
+                                        "code": "OBJ"
+                                    }
+                                },
+                                {
+                                    "id": 6378387,
+                                    "name": "Türhöhe Rohbaumaß",
+                                    "code": null,
+                                    "description": "Türliste, Detailangabe",
+                                    "datatype": "Property",
+                                    "parent_id": 6378281,
+                                    "template_id": 6378196,
+                                    "updated_at": "2021-09-29T10:38:44.394+02:00",
+                                    "unit": "Länge.m",
+                                    "unit_reference": "Measurements.IfcLengthMeasure.METRE",
+                                    "actor": {
+                                        "id": 5679,
+                                        "name": "CKPlaner",
+                                        "code": "OBJ"
+                                    }
+                                },
+                                {
+                                    "id": 6378388,
+                                    "name": "Türschliesser",
+                                    "code": null,
+                                    "description": "Ausstattung von Türen: Türschliesser.",
+                                    "datatype": "Property",
+                                    "parent_id": 6378281,
+                                    "template_id": 6378197,
+                                    "updated_at": "2021-09-29T10:38:44.394+02:00",
+                                    "unit": "Wahr/Falsch",
+                                    "unit_reference": "Datatypes.IfcBoolean",
+                                    "actor": {
+                                        "id": 5679,
+                                        "name": "CKPlaner",
+                                        "code": "OBJ"
+                                    }
+                                },
+                                {
+                                    "id": 6378389,
+                                    "name": "Zargenart",
+                                    "code": null,
+                                    "description": "Türliste, Detailangabe",
+                                    "datatype": "Property",
+                                    "parent_id": 6378281,
+                                    "template_id": 6378198,
+                                    "updated_at": "2021-09-29T10:38:44.394+02:00",
+                                    "unit": "Kennzeichen",
+                                    "unit_reference": "Datatypes.IfcLabel",
+                                    "actor": {
+                                        "id": 5679,
+                                        "name": "CKPlaner",
+                                        "code": "OBJ"
+                                    }
+                                },
+                                {
+                                    "id": 6378390,
+                                    "name": "Zargenstärke",
+                                    "code": null,
+                                    "description": "Türliste, Detailangabe",
+                                    "datatype": "Property",
+                                    "parent_id": 6378281,
+                                    "template_id": 6378199,
+                                    "updated_at": "2021-09-29T10:38:44.394+02:00",
+                                    "unit": "Länge.m",
+                                    "unit_reference": "Measurements.IfcLengthMeasure.METRE",
+                                    "actor": {
+                                        "id": 5679,
+                                        "name": "CKPlaner",
+                                        "code": "OBJ"
+                                    }
+                                },
+                                {
+                                    "id": 6378391,
+                                    "name": "Zargentiefe",
+                                    "code": null,
+                                    "description": "Türliste, Detailangabe",
+                                    "datatype": "Property",
+                                    "parent_id": 6378281,
+                                    "template_id": 6378200,
+                                    "updated_at": "2021-09-29T10:38:44.394+02:00",
+                                    "unit": "Länge.m",
+                                    "unit_reference": "Measurements.IfcLengthMeasure.METRE",
+                                    "actor": {
+                                        "id": 5679,
+                                        "name": "CKPlaner",
+                                        "code": "OBJ"
+                                    }
+                                },
+                                {
+                                    "id": 6378392,
+                                    "name": "Zulassungsnummer",
+                                    "code": null,
+                                    "description": "Türliste, Detailangabe",
+                                    "datatype": "Property",
+                                    "parent_id": 6378281,
+                                    "template_id": 6378201,
+                                    "updated_at": "2021-09-29T10:38:44.394+02:00",
+                                    "unit": "Kennzeichen",
+                                    "unit_reference": "Datatypes.IfcLabel",
+                                    "actor": {
+                                        "id": 5679,
+                                        "name": "CKPlaner",
+                                        "code": "OBJ"
+                                    }
                                 }
                             ]
                         },
                         {
                             "id": 6378282,
                             "name": "spezieller Eigenschaftssatz Türen, Fenster",
+                            "code": "03-05-03",
                             "description": null,
                             "datatype": "Group",
                             "parent_id": 6378258,
@@ -1603,24 +3310,41 @@
                                 {
                                     "id": 6378393,
                                     "name": "Anzahl der Scheiben",
+                                    "code": null,
                                     "description": null,
                                     "datatype": "Property",
                                     "parent_id": 6378282,
                                     "template_id": 6378202,
-                                    "updated_at": "2021-09-29T10:38:44.394+02:00"
+                                    "updated_at": "2021-09-29T10:38:44.394+02:00",
+                                    "unit": "ganze Zahl",
+                                    "unit_reference": "Datatypes.IfcInteger",
+                                    "actor": {
+                                        "id": 5679,
+                                        "name": "CKPlaner",
+                                        "code": "OBJ"
+                                    }
                                 },
                                 {
                                     "id": 6378394,
                                     "name": "Aufschlagrichtung",
+                                    "code": null,
                                     "description": "Aufschlagsrichtung von Türen und Fenstern",
                                     "datatype": "Property",
                                     "parent_id": 6378282,
                                     "template_id": 6378203,
                                     "updated_at": "2021-09-29T10:38:44.394+02:00",
+                                    "unit": "Kennzeichen",
+                                    "unit_reference": "Datatypes.IfcLabel",
+                                    "actor": {
+                                        "id": 5679,
+                                        "name": "CKPlaner",
+                                        "code": "OBJ"
+                                    },
                                     "child_concept": [
                                         {
                                             "id": 6378437,
                                             "name": "DIN L",
+                                            "code": "00",
                                             "description": null,
                                             "datatype": "Restriction",
                                             "parent_id": 6378394,
@@ -1630,6 +3354,7 @@
                                         {
                                             "id": 6378438,
                                             "name": "DIN R",
+                                            "code": "01",
                                             "description": null,
                                             "datatype": "Restriction",
                                             "parent_id": 6378394,
@@ -1641,15 +3366,24 @@
                                 {
                                     "id": 6378395,
                                     "name": "Einbruchschutz",
+                                    "code": null,
                                     "description": "Widerstandsklassen – Einbruchhemmende Bauteile nach DIN EN 1627",
                                     "datatype": "Property",
                                     "parent_id": 6378282,
                                     "template_id": 6378204,
                                     "updated_at": "2021-09-29T10:38:44.394+02:00",
+                                    "unit": "Kennzeichen",
+                                    "unit_reference": "Datatypes.IfcLabel",
+                                    "actor": {
+                                        "id": 5679,
+                                        "name": "CKPlaner",
+                                        "code": "OBJ"
+                                    },
                                     "child_concept": [
                                         {
                                             "id": 6378439,
                                             "name": "RC1N",
+                                            "code": "00",
                                             "description": null,
                                             "datatype": "Restriction",
                                             "parent_id": 6378395,
@@ -1659,6 +3393,7 @@
                                         {
                                             "id": 6378440,
                                             "name": "RC2N",
+                                            "code": "01",
                                             "description": null,
                                             "datatype": "Restriction",
                                             "parent_id": 6378395,
@@ -1668,6 +3403,7 @@
                                         {
                                             "id": 6378441,
                                             "name": "RC2",
+                                            "code": "02",
                                             "description": null,
                                             "datatype": "Restriction",
                                             "parent_id": 6378395,
@@ -1677,6 +3413,7 @@
                                         {
                                             "id": 6378442,
                                             "name": "RC3",
+                                            "code": "03",
                                             "description": null,
                                             "datatype": "Restriction",
                                             "parent_id": 6378395,
@@ -1686,6 +3423,7 @@
                                         {
                                             "id": 6378443,
                                             "name": "RC4",
+                                            "code": "04",
                                             "description": null,
                                             "datatype": "Restriction",
                                             "parent_id": 6378395,
@@ -1695,6 +3433,7 @@
                                         {
                                             "id": 6378444,
                                             "name": "RC5",
+                                            "code": "05",
                                             "description": null,
                                             "datatype": "Restriction",
                                             "parent_id": 6378395,
@@ -1704,6 +3443,7 @@
                                         {
                                             "id": 6378445,
                                             "name": "RC6",
+                                            "code": "06",
                                             "description": null,
                                             "datatype": "Restriction",
                                             "parent_id": 6378395,
@@ -1715,26 +3455,43 @@
                                 {
                                     "id": 6378396,
                                     "name": "Glasfläche",
+                                    "code": null,
                                     "description": null,
                                     "datatype": "Property",
                                     "parent_id": 6378282,
                                     "template_id": 6378205,
-                                    "updated_at": "2021-09-29T10:38:44.394+02:00"
+                                    "updated_at": "2021-09-29T10:38:44.394+02:00",
+                                    "unit": "Fläche.m2",
+                                    "unit_reference": "Measurements.IfcAreaMeasure.SQUARE_METRE",
+                                    "actor": {
+                                        "id": 5679,
+                                        "name": "CKPlaner",
+                                        "code": "OBJ"
+                                    }
                                 },
                                 {
                                     "id": 6378397,
                                     "name": "Sturzhöhe",
+                                    "code": null,
                                     "description": null,
                                     "datatype": "Property",
                                     "parent_id": 6378282,
                                     "template_id": 6378206,
-                                    "updated_at": "2021-09-29T10:38:44.394+02:00"
+                                    "updated_at": "2021-09-29T10:38:44.394+02:00",
+                                    "unit": "Länge",
+                                    "unit_reference": "Measurements.IfcLengthMeasure",
+                                    "actor": {
+                                        "id": 5679,
+                                        "name": "CKPlaner",
+                                        "code": "OBJ"
+                                    }
                                 }
                             ]
                         },
                         {
                             "id": 6378283,
                             "name": "spezieller Eigenschaftssatz Brandschutz",
+                            "code": "05-02",
                             "description": null,
                             "datatype": "Group",
                             "parent_id": 6378258,
@@ -1744,26 +3501,43 @@
                                 {
                                     "id": 6378398,
                                     "name": "Brandfallsteuerung",
+                                    "code": null,
                                     "description": "Türschliesser, Rauchklappen in Treppenhäusern etc.",
                                     "datatype": "Property",
                                     "parent_id": 6378283,
                                     "template_id": 6378207,
-                                    "updated_at": "2021-09-29T10:38:44.394+02:00"
+                                    "updated_at": "2021-09-29T10:38:44.394+02:00",
+                                    "unit": "Kennzeichen",
+                                    "unit_reference": "Datatypes.IfcLabel",
+                                    "actor": {
+                                        "id": 5679,
+                                        "name": "CKPlaner",
+                                        "code": "OBJ"
+                                    }
                                 },
                                 {
                                     "id": 6378399,
                                     "name": "Rauchabzugsfunktion Bauteil",
+                                    "code": null,
                                     "description": "z.B. Dachoberlichter, Fassadenelemente, Fenster oder spezielle Klappen. Abhängig von Brandschutzkonzept.",
                                     "datatype": "Property",
                                     "parent_id": 6378283,
                                     "template_id": 6378208,
-                                    "updated_at": "2021-09-29T10:38:44.394+02:00"
+                                    "updated_at": "2021-09-29T10:38:44.394+02:00",
+                                    "unit": "Kennzeichen",
+                                    "unit_reference": "Datatypes.IfcLabel",
+                                    "actor": {
+                                        "id": 5679,
+                                        "name": "CKPlaner",
+                                        "code": "OBJ"
+                                    }
                                 }
                             ]
                         },
                         {
                             "id": 6378284,
                             "name": "spezieller Eigenschaftssatz Sicherheit",
+                            "code": "05-07",
                             "description": null,
                             "datatype": "Group",
                             "parent_id": 6378258,
@@ -1773,152 +3547,3383 @@
                                 {
                                     "id": 6378400,
                                     "name": "VSG Fläche",
+                                    "code": null,
                                     "description": "Fläche des VS-Glases",
                                     "datatype": "Property",
                                     "parent_id": 6378284,
                                     "template_id": 6378209,
-                                    "updated_at": "2021-09-29T10:38:44.394+02:00"
+                                    "updated_at": "2021-09-29T10:38:44.394+02:00",
+                                    "unit": "Fläche",
+                                    "unit_reference": "Measurements.IfcAreaMeasure",
+                                    "actor": {
+                                        "id": 5679,
+                                        "name": "CKPlaner",
+                                        "code": "OBJ"
+                                    }
                                 },
                                 {
                                     "id": 6378401,
                                     "name": "VSG Kennzeichnung",
+                                    "code": null,
                                     "description": "Markierung und Typenbezeichnungen des VS-Glases",
                                     "datatype": "Property",
                                     "parent_id": 6378284,
                                     "template_id": 6378210,
-                                    "updated_at": "2021-09-29T10:38:44.394+02:00"
+                                    "updated_at": "2021-09-29T10:38:44.394+02:00",
+                                    "unit": "Kennzeichen",
+                                    "unit_reference": "Datatypes.IfcLabel",
+                                    "actor": {
+                                        "id": 5679,
+                                        "name": "CKPlaner",
+                                        "code": "OBJ"
+                                    }
                                 }
                             ]
                         }
                     ]
                 },
                 {
-                    "id": 6378257,
-                    "name": "Wand",
+                    "id": 6461820,
+                    "name": "Werkstatt",
+                    "code": null,
                     "description": null,
                     "datatype": "Type",
                     "parent_id": 6378243,
-                    "template_id": 6378155,
-                    "updated_at": "2022-01-21T09:10:39.482+01:00",
-                    "map_item": "IfcWall",
-                    "map_item_id": 3124067,
+                    "template_id": 6378105,
+                    "updated_at": "2022-02-17T18:17:17.115+01:00",
+                    "map_item_id": 3205247,
+                    "map_item": "IfcSpace",
                     "child_concept": [
                         {
-                            "id": 6378275,
-                            "name": "gemeinsame Eigenschaften",
+                            "id": 6461823,
+                            "name": "Kopfdaten",
+                            "code": null,
                             "description": null,
                             "datatype": "Group",
-                            "parent_id": 6378257,
-                            "template_id": 6378108,
-                            "updated_at": "2021-09-29T10:38:44.394+02:00",
+                            "parent_id": 6461820,
+                            "template_id": 6461821,
+                            "updated_at": "2022-08-11T08:55:14.240+02:00",
                             "child_concept": [
                                 {
-                                    "id": 6378359,
-                                    "name": "Außenbauteil",
+                                    "id": 6461826,
+                                    "name": "Raumhöhe",
+                                    "code": "123",
                                     "description": null,
                                     "datatype": "Property",
-                                    "parent_id": 6378275,
-                                    "template_id": 6378137,
-                                    "updated_at": "2021-09-29T10:38:44.394+02:00",
-                                    "map_item": "*.IsExternal",
-                                    "map_item_id": 3123893
-                                },
-                                {
-                                    "id": 6378360,
-                                    "name": "Bauteiltyp",
-                                    "description": null,
-                                    "datatype": "Property",
-                                    "parent_id": 6378275,
-                                    "template_id": 6378139,
-                                    "updated_at": "2021-09-29T10:38:44.394+02:00",
-                                    "map_item": "*.Reference",
-                                    "map_item_id": 3123945
-                                },
-                                {
-                                    "id": 6378361,
-                                    "name": "Feuerwiderstandsklasse",
-                                    "description": null,
-                                    "datatype": "Property",
-                                    "parent_id": 6378275,
-                                    "template_id": 6378140,
-                                    "updated_at": "2021-09-29T10:38:44.394+02:00",
-                                    "map_item": "*.FireRating",
-                                    "map_item_id": 3123946,
+                                    "parent_id": 6461823,
+                                    "template_id": 6461825,
+                                    "updated_at": "2022-02-17T18:13:37.994+01:00",
+                                    "unit": "Kennzeichen",
+                                    "unit_reference": "Datatypes.IfcLabel",
+                                    "map_item_id": 3205235,
+                                    "map_item": "#.Raumhöhe",
+                                    "actor": {
+                                        "id": 5679,
+                                        "name": "CKPlaner",
+                                        "code": "OBJ"
+                                    },
                                     "child_concept": [
                                         {
-                                            "id": 6378418,
+                                            "id": 6461833,
+                                            "name": "3 m",
+                                            "code": null,
+                                            "description": null,
+                                            "datatype": "Restriction",
+                                            "parent_id": 6461826,
+                                            "template_id": 6461832,
+                                            "updated_at": "2022-02-17T18:18:46.704+01:00"
+                                        }
+                                    ]
+                                }
+                            ]
+                        },
+                        {
+                            "id": 6520770,
+                            "name": "gemeinsame Eigenschaften",
+                            "code": "01",
+                            "description": null,
+                            "datatype": "Group",
+                            "parent_id": 6461820,
+                            "template_id": 6378275,
+                            "updated_at": "2022-08-03T14:06:10.963+02:00",
+                            "child_concept": [
+                                {
+                                    "id": 6520791,
+                                    "name": "Raumname",
+                                    "code": null,
+                                    "description": null,
+                                    "datatype": "Property",
+                                    "parent_id": 6520770,
+                                    "template_id": 6378149,
+                                    "updated_at": "2022-08-03T14:10:01.673+02:00",
+                                    "unit": "Kennzeichen",
+                                    "unit_reference": "Datatypes.IfcLabel",
+                                    "map_item_id": 3123976,
+                                    "map_item": "IfcSpatialElement Attributes.LongName",
+                                    "actor": {
+                                        "id": 5679,
+                                        "name": "CKPlaner",
+                                        "code": "OBJ"
+                                    }
+                                },
+                                {
+                                    "id": 6520771,
+                                    "name": "Wärmedurchgangskoeffizient  (U-Wert)",
+                                    "code": null,
+                                    "description": null,
+                                    "datatype": "Property",
+                                    "parent_id": 6520770,
+                                    "template_id": 6378363,
+                                    "updated_at": "2022-08-03T14:06:10.972+02:00",
+                                    "unit": "Wärmedurchgängigkeit",
+                                    "unit_reference": "Measurements.IfcThermalTransmittanceMeasure",
+                                    "actor": {
+                                        "id": 5679,
+                                        "name": "CKPlaner",
+                                        "code": "OBJ"
+                                    }
+                                },
+                                {
+                                    "id": 6520772,
+                                    "name": "Spannweite",
+                                    "code": null,
+                                    "description": null,
+                                    "datatype": "Property",
+                                    "parent_id": 6520770,
+                                    "template_id": 6519819,
+                                    "updated_at": "2022-08-03T14:06:10.981+02:00",
+                                    "unit": "Länge (positiv, \u003e0)",
+                                    "unit_reference": "Measurements.IfcPositiveLengthMeasure",
+                                    "actor": {
+                                        "id": 5679,
+                                        "name": "CKPlaner",
+                                        "code": "OBJ"
+                                    }
+                                },
+                                {
+                                    "id": 6520773,
+                                    "name": "Bauteiltyp",
+                                    "code": null,
+                                    "description": null,
+                                    "datatype": "Property",
+                                    "parent_id": 6520770,
+                                    "template_id": 6378360,
+                                    "updated_at": "2022-08-03T14:06:10.984+02:00",
+                                    "unit": "Identifizierungszeichen",
+                                    "unit_reference": "Datatypes.IfcIdentifier",
+                                    "actor": {
+                                        "id": 5679,
+                                        "name": "CKPlaner",
+                                        "code": "OBJ"
+                                    }
+                                },
+                                {
+                                    "id": 6520774,
+                                    "name": "Außenbauteil",
+                                    "code": null,
+                                    "description": null,
+                                    "datatype": "Property",
+                                    "parent_id": 6520770,
+                                    "template_id": 6378359,
+                                    "updated_at": "2022-08-03T14:06:10.988+02:00",
+                                    "unit": "Wahr/Falsch",
+                                    "unit_reference": "Datatypes.IfcBoolean",
+                                    "actor": {
+                                        "id": 5679,
+                                        "name": "CKPlaner",
+                                        "code": "OBJ"
+                                    }
+                                },
+                                {
+                                    "id": 6520775,
+                                    "name": "Testeigenschaft",
+                                    "code": null,
+                                    "description": null,
+                                    "datatype": "Property",
+                                    "parent_id": 6520770,
+                                    "template_id": 6519820,
+                                    "updated_at": "2022-08-03T14:06:10.994+02:00",
+                                    "unit": "Kennzeichen",
+                                    "unit_reference": "Datatypes.IfcLabel",
+                                    "actor": {
+                                        "id": 5679,
+                                        "name": "CKPlaner",
+                                        "code": "OBJ"
+                                    }
+                                },
+                                {
+                                    "id": 6520776,
+                                    "name": "Tragendes Bauteil",
+                                    "code": null,
+                                    "description": null,
+                                    "datatype": "Property",
+                                    "parent_id": 6520770,
+                                    "template_id": 6378362,
+                                    "updated_at": "2022-08-03T14:06:10.998+02:00",
+                                    "unit": "Wahr/Falsch",
+                                    "unit_reference": "Datatypes.IfcBoolean",
+                                    "actor": {
+                                        "id": 5679,
+                                        "name": "CKPlaner",
+                                        "code": "OBJ"
+                                    }
+                                },
+                                {
+                                    "id": 6520777,
+                                    "name": "Feuerwiderstandsklasse",
+                                    "code": null,
+                                    "description": null,
+                                    "datatype": "Property",
+                                    "parent_id": 6520770,
+                                    "template_id": 6378361,
+                                    "updated_at": "2022-08-03T14:06:11.006+02:00",
+                                    "unit": "Kennzeichen",
+                                    "unit_reference": "Datatypes.IfcLabel",
+                                    "actor": {
+                                        "id": 5679,
+                                        "name": "CKPlaner",
+                                        "code": "OBJ"
+                                    },
+                                    "child_concept": [
+                                        {
+                                            "id": 6520780,
+                                            "name": "F200",
+                                            "code": null,
+                                            "description": null,
+                                            "datatype": "Restriction",
+                                            "parent_id": 6520777,
+                                            "template_id": 6519804,
+                                            "updated_at": "2022-08-03T14:06:11.018+02:00"
+                                        },
+                                        {
+                                            "id": 6520779,
+                                            "name": "70",
+                                            "code": null,
+                                            "description": null,
+                                            "datatype": "Restriction",
+                                            "parent_id": 6520777,
+                                            "template_id": 6519802,
+                                            "updated_at": "2022-08-03T14:06:11.015+02:00"
+                                        },
+                                        {
+                                            "id": 6520783,
                                             "name": "F30",
+                                            "code": null,
                                             "description": null,
                                             "datatype": "Restriction",
-                                            "parent_id": 6378361,
-                                            "template_id": 6378211,
-                                            "updated_at": "2021-09-29T10:38:44.394+02:00"
+                                            "parent_id": 6520777,
+                                            "template_id": 6378418,
+                                            "updated_at": "2022-08-03T14:06:11.026+02:00"
                                         },
                                         {
-                                            "id": 6378419,
+                                            "id": 6520781,
+                                            "name": "ABC",
+                                            "code": null,
+                                            "description": null,
+                                            "datatype": "Restriction",
+                                            "parent_id": 6520777,
+                                            "template_id": 6519803,
+                                            "updated_at": "2022-08-03T14:06:11.021+02:00"
+                                        },
+                                        {
+                                            "id": 6520782,
                                             "name": "F60",
+                                            "code": null,
                                             "description": null,
                                             "datatype": "Restriction",
-                                            "parent_id": 6378361,
-                                            "template_id": 6378212,
-                                            "updated_at": "2021-09-29T10:38:44.394+02:00"
+                                            "parent_id": 6520777,
+                                            "template_id": 6378419,
+                                            "updated_at": "2022-08-03T14:06:11.023+02:00"
                                         },
                                         {
-                                            "id": 6378420,
+                                            "id": 6520778,
                                             "name": "F90",
+                                            "code": null,
                                             "description": null,
                                             "datatype": "Restriction",
-                                            "parent_id": 6378361,
-                                            "template_id": 6378213,
-                                            "updated_at": "2021-09-29T10:38:44.394+02:00"
+                                            "parent_id": 6520777,
+                                            "template_id": 6378420,
+                                            "updated_at": "2022-08-03T14:06:11.012+02:00"
+                                        }
+                                    ]
+                                }
+                            ]
+                        },
+                        {
+                            "id": 6520784,
+                            "name": "CKs Eigenschaften (Konzeptname!)",
+                            "code": null,
+                            "description": null,
+                            "datatype": "Group",
+                            "parent_id": 6461820,
+                            "template_id": 6378110,
+                            "updated_at": "2022-08-03T14:09:53.188+02:00",
+                            "map_item_id": 3123981,
+                            "map_item": "CKs Eigenschaften",
+                            "child_concept": [
+                                {
+                                    "id": 6520785,
+                                    "name": "Raumnummer",
+                                    "code": null,
+                                    "description": null,
+                                    "datatype": "Property",
+                                    "parent_id": 6520784,
+                                    "template_id": 6378150,
+                                    "updated_at": "2022-08-03T14:09:53.201+02:00",
+                                    "unit": "Kennzeichen",
+                                    "unit_reference": "Datatypes.IfcLabel",
+                                    "map_item_id": 3123977,
+                                    "map_item": "IfcElement Attributes.Name",
+                                    "actor": {
+                                        "id": 5679,
+                                        "name": "CKPlaner",
+                                        "code": "OBJ"
+                                    }
+                                },
+                                {
+                                    "id": 6520786,
+                                    "name": "Test Bauteil",
+                                    "code": null,
+                                    "description": null,
+                                    "datatype": "Property",
+                                    "parent_id": 6520784,
+                                    "template_id": 6378146,
+                                    "updated_at": "2022-08-03T14:09:53.211+02:00",
+                                    "unit": "Wahr/Falsch",
+                                    "unit_reference": "Datatypes.IfcBoolean",
+                                    "map_item_id": 3123922,
+                                    "map_item": "#.Test Bauteil",
+                                    "actor": {
+                                        "id": 5679,
+                                        "name": "CKPlaner",
+                                        "code": "OBJ"
+                                    }
+                                },
+                                {
+                                    "id": 6520787,
+                                    "name": "AttributName",
+                                    "code": null,
+                                    "description": null,
+                                    "datatype": "Property",
+                                    "parent_id": 6520784,
+                                    "template_id": 6378143,
+                                    "updated_at": "2022-08-03T14:09:53.222+02:00",
+                                    "unit": "Kennzeichen",
+                                    "unit_reference": "Datatypes.IfcLabel",
+                                    "map_item_id": 3123958,
+                                    "map_item": "IfcElement Attributes.Name",
+                                    "actor": {
+                                        "id": 5679,
+                                        "name": "CKPlaner",
+                                        "code": "OBJ"
+                                    }
+                                },
+                                {
+                                    "id": 6520788,
+                                    "name": "CKBauteiltyp",
+                                    "code": null,
+                                    "description": null,
+                                    "datatype": "Property",
+                                    "parent_id": 6520784,
+                                    "template_id": 6378144,
+                                    "updated_at": "2022-08-03T14:09:53.233+02:00",
+                                    "unit": "Kennzeichen",
+                                    "unit_reference": "Datatypes.IfcLabel",
+                                    "map_item_id": 3124009,
+                                    "map_item": "#.CKBauteiltyp",
+                                    "actor": {
+                                        "id": 5679,
+                                        "name": "CKPlaner",
+                                        "code": "OBJ"
+                                    },
+                                    "child_concept": [
+                                        {
+                                            "id": 6520789,
+                                            "name": "Testwert",
+                                            "code": "1212",
+                                            "description": null,
+                                            "datatype": "Restriction",
+                                            "parent_id": 6520788,
+                                            "template_id": 6470184,
+                                            "updated_at": "2022-08-03T14:09:53.240+02:00"
                                         }
                                     ]
                                 },
                                 {
-                                    "id": 6378362,
-                                    "name": "Tragendes Bauteil",
+                                    "id": 6520790,
+                                    "name": "CKsBeschreibung",
+                                    "code": null,
                                     "description": null,
                                     "datatype": "Property",
-                                    "parent_id": 6378275,
-                                    "template_id": 6378138,
-                                    "updated_at": "2021-09-29T10:38:44.394+02:00",
-                                    "map_item": "*.LoadBearing",
-                                    "map_item_id": 3123900
+                                    "parent_id": 6520784,
+                                    "template_id": 6378145,
+                                    "updated_at": "2022-08-03T14:09:53.247+02:00",
+                                    "unit": "Kennzeichen",
+                                    "unit_reference": "Datatypes.IfcLabel",
+                                    "map_item_id": 3123960,
+                                    "map_item": "IfcElement Attributes.Description",
+                                    "actor": {
+                                        "id": 5679,
+                                        "name": "CKPlaner",
+                                        "code": "OBJ"
+                                    }
                                 },
                                 {
-                                    "id": 6378363,
-                                    "name": "Wärmedurchgangskoeffizient  (U-Wert)",
+                                    "id": 6520792,
+                                    "name": "Testwert",
+                                    "code": null,
                                     "description": null,
                                     "datatype": "Property",
-                                    "parent_id": 6378275,
-                                    "template_id": 6378142,
-                                    "updated_at": "2022-06-21T09:46:33.463+02:00",
-                                    "map_item": "*.ThermalTransmittance",
-                                    "map_item_id": 3123948
+                                    "parent_id": 6520784,
+                                    "template_id": 6378154,
+                                    "updated_at": "2022-08-03T14:09:53.266+02:00",
+                                    "unit": "Länge (nicht-negativ, \u003e=0).m",
+                                    "unit_reference": "Measurements.IfcNonNegativeLengthMeasure.METRE",
+                                    "map_item_id": 3124007,
+                                    "map_item": "#.Testwert",
+                                    "actor": {
+                                        "id": 5679,
+                                        "name": "CKPlaner",
+                                        "code": "OBJ"
+                                    }
                                 }
                             ]
                         }
                     ]
+                },
+                {
+                    "id": 6754024,
+                    "name": "PipeFitting",
+                    "code": null,
+                    "description": null,
+                    "datatype": "Type",
+                    "parent_id": 6378243,
+                    "template_id": 6754023,
+                    "updated_at": "2023-04-28T15:13:22.189+02:00",
+                    "map_item_id": 3392768,
+                    "map_item": "IfcPipeFitting",
+                    "child_concept": [
+                        {
+                            "id": 6754025,
+                            "name": "CKs Eigenschaften (Konzeptname!)",
+                            "code": null,
+                            "description": null,
+                            "datatype": "Group",
+                            "parent_id": 6754024,
+                            "template_id": 6378110,
+                            "updated_at": "2023-04-28T15:13:22.245+02:00",
+                            "map_item_id": 3123981,
+                            "map_item": "CKs Eigenschaften",
+                            "child_concept": [
+                                {
+                                    "id": 6754030,
+                                    "name": "CKsBeschreibung",
+                                    "code": null,
+                                    "description": null,
+                                    "datatype": "Property",
+                                    "parent_id": 6754025,
+                                    "template_id": 6378145,
+                                    "updated_at": "2023-04-28T15:13:22.245+02:00",
+                                    "unit": "Kennzeichen",
+                                    "unit_reference": "Datatypes.IfcLabel",
+                                    "map_item_id": 3123960,
+                                    "map_item": "IfcElement Attributes.Description",
+                                    "actor": {
+                                        "id": 5680,
+                                        "name": "TGAler",
+                                        "code": "TGA"
+                                    }
+                                },
+                                {
+                                    "id": 6754031,
+                                    "name": "CKBauteiltyp",
+                                    "code": null,
+                                    "description": null,
+                                    "datatype": "Property",
+                                    "parent_id": 6754025,
+                                    "template_id": 6378144,
+                                    "updated_at": "2023-04-28T15:13:22.245+02:00",
+                                    "unit": "Kennzeichen",
+                                    "unit_reference": "Datatypes.IfcLabel",
+                                    "map_item_id": 3124009,
+                                    "map_item": "#.CKBauteiltyp",
+                                    "actor": {
+                                        "id": 5680,
+                                        "name": "TGAler",
+                                        "code": "TGA"
+                                    }
+                                },
+                                {
+                                    "id": 6754032,
+                                    "name": "Raumname",
+                                    "code": null,
+                                    "description": null,
+                                    "datatype": "Property",
+                                    "parent_id": 6754025,
+                                    "template_id": 6378149,
+                                    "updated_at": "2023-04-28T15:13:22.245+02:00",
+                                    "unit": "Kennzeichen",
+                                    "unit_reference": "Datatypes.IfcLabel",
+                                    "map_item_id": 3123976,
+                                    "map_item": "IfcSpatialElement Attributes.LongName",
+                                    "actor": {
+                                        "id": 5680,
+                                        "name": "TGAler",
+                                        "code": "TGA"
+                                    }
+                                },
+                                {
+                                    "id": 6754026,
+                                    "name": "Raumnummer",
+                                    "code": null,
+                                    "description": null,
+                                    "datatype": "Property",
+                                    "parent_id": 6754025,
+                                    "template_id": 6378150,
+                                    "updated_at": "2023-04-28T15:13:22.245+02:00",
+                                    "unit": "Kennzeichen",
+                                    "unit_reference": "Datatypes.IfcLabel",
+                                    "map_item_id": 3123977,
+                                    "map_item": "IfcElement Attributes.Name",
+                                    "actor": {
+                                        "id": 5680,
+                                        "name": "TGAler",
+                                        "code": "TGA"
+                                    }
+                                },
+                                {
+                                    "id": 6754027,
+                                    "name": "AttributName",
+                                    "code": null,
+                                    "description": null,
+                                    "datatype": "Property",
+                                    "parent_id": 6754025,
+                                    "template_id": 6378143,
+                                    "updated_at": "2023-04-28T15:13:22.245+02:00",
+                                    "unit": "Kennzeichen",
+                                    "unit_reference": "Datatypes.IfcLabel",
+                                    "map_item_id": 3123958,
+                                    "map_item": "IfcElement Attributes.Name",
+                                    "actor": {
+                                        "id": 5680,
+                                        "name": "TGAler",
+                                        "code": "TGA"
+                                    }
+                                },
+                                {
+                                    "id": 6754028,
+                                    "name": "Test Bauteil",
+                                    "code": null,
+                                    "description": null,
+                                    "datatype": "Property",
+                                    "parent_id": 6754025,
+                                    "template_id": 6378146,
+                                    "updated_at": "2023-04-28T15:13:22.245+02:00",
+                                    "unit": "Wahr/Falsch",
+                                    "unit_reference": "Datatypes.IfcBoolean",
+                                    "map_item_id": 3123922,
+                                    "map_item": "#.Test Bauteil",
+                                    "actor": {
+                                        "id": 5680,
+                                        "name": "TGAler",
+                                        "code": "TGA"
+                                    }
+                                },
+                                {
+                                    "id": 6754029,
+                                    "name": "Testwert",
+                                    "code": null,
+                                    "description": null,
+                                    "datatype": "Property",
+                                    "parent_id": 6754025,
+                                    "template_id": 6378154,
+                                    "updated_at": "2023-04-28T15:13:22.245+02:00",
+                                    "unit": "Länge (nicht-negativ, \u003e=0).m",
+                                    "unit_reference": "Measurements.IfcNonNegativeLengthMeasure.METRE",
+                                    "map_item_id": 3124007,
+                                    "map_item": "#.Testwert",
+                                    "actor": {
+                                        "id": 5680,
+                                        "name": "TGAler",
+                                        "code": "TGA"
+                                    }
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "id": 6860433,
+                    "name": "Testbauteil",
+                    "code": "2-06",
+                    "description": null,
+                    "datatype": "Type",
+                    "parent_id": 6378243,
+                    "template_id": 6378120,
+                    "updated_at": "2023-04-28T15:14:10.938+02:00",
+                    "map_item_id": 3123995,
+                    "map_item": "IfcBuildingElementProxy"
+                },
+                {
+                    "id": 6860434,
+                    "name": "allgemeines Bauteil (ABC)",
+                    "code": "2-05",
+                    "description": null,
+                    "datatype": "Type",
+                    "parent_id": 6378243,
+                    "template_id": 6378101,
+                    "updated_at": "2023-04-28T15:14:16.048+02:00",
+                    "map_item_id": 3123908,
+                    "map_item": "IfcBuildingElementProxy.##.##.CKs Eigenschaften.CKBauteiltyp:\"ABC\""
+                },
+                {
+                    "id": 6860435,
+                    "name": "MeinBauteil",
+                    "code": null,
+                    "description": null,
+                    "datatype": "Type",
+                    "parent_id": 6378243,
+                    "template_id": 6378116,
+                    "updated_at": "2023-04-28T15:14:21.842+02:00",
+                    "map_item_id": 3124056,
+                    "map_item": "IfcWindow"
                 }
             ]
         },
         {
             "id": 6378246,
             "name": "Heizungsmodell",
+            "code": "03",
             "description": null,
             "datatype": "Model",
             "parent_id": null,
             "template_id": 6378115,
-            "updated_at": "2021-09-29T10:38:44.394+02:00"
+            "updated_at": "2021-09-29T10:38:44.394+02:00",
+            "actor": {
+                "id": 5680,
+                "name": "TGAler",
+                "code": "TGA"
+            }
+        },
+        {
+            "id": 6378244,
+            "name": "TGA Modell",
+            "code": "02",
+            "description": null,
+            "datatype": "Model",
+            "parent_id": null,
+            "template_id": 6378113,
+            "updated_at": "2021-09-29T10:38:44.394+02:00",
+            "actor": {
+                "id": 5680,
+                "name": "TGAler",
+                "code": "TGA"
+            }
+        },
+        {
+            "id": 6378245,
+            "name": "TWP Modell",
+            "code": "02",
+            "description": null,
+            "datatype": "Model",
+            "parent_id": null,
+            "template_id": 6378114,
+            "updated_at": "2021-09-29T10:38:44.394+02:00",
+            "actor": {
+                "id": 5681,
+                "name": "Statiker",
+                "code": "TWP"
+            }
         },
         {
             "id": 6378247,
             "name": "Architekturmodell",
+            "code": "1-OBJ",
             "description": "Das Architekturmodell ist die digitale Abbildung des geplanten Bauwerks aus architektonischer Sicht. Es wird als Basis für alle nachfolgen Fachmodelle verwendet.",
             "datatype": "Model",
             "parent_id": null,
             "template_id": 6378117,
             "updated_at": "2021-09-29T10:38:44.394+02:00"
+        },
+        {
+            "id": 6583092,
+            "name": "Testmodell",
+            "code": "69",
+            "description": null,
+            "datatype": "Model",
+            "parent_id": null,
+            "template_id": 6583091,
+            "updated_at": "2022-08-26T10:34:49.920+02:00",
+            "child_concept": [
+                {
+                    "id": 6583190,
+                    "name": "Tür",
+                    "code": "02-04-01",
+                    "description": null,
+                    "datatype": "Type",
+                    "parent_id": 6583092,
+                    "template_id": 6378172,
+                    "updated_at": "2022-08-26T10:35:06.446+02:00",
+                    "map_item_id": 3309327,
+                    "map_item": "IfcDoor",
+                    "child_concept": [
+                        {
+                            "id": 6583195,
+                            "name": "gemeinsame Eigenschaften Bauteile (IFC)",
+                            "code": "01-01-02",
+                            "description": "Kopfdaten für alle Modellelemente nach IFC",
+                            "datatype": "Group",
+                            "parent_id": 6583190,
+                            "template_id": 6378130,
+                            "updated_at": "2022-08-26T10:35:06.454+02:00",
+                            "child_concept": [
+                                {
+                                    "id": 6583198,
+                                    "name": "Beschreibung",
+                                    "code": "03",
+                                    "description": null,
+                                    "datatype": "Property",
+                                    "parent_id": 6583195,
+                                    "template_id": 6378181,
+                                    "updated_at": "2022-08-26T10:35:06.461+02:00",
+                                    "unit": "Kennzeichen",
+                                    "unit_reference": "Datatypes.IfcLabel"
+                                },
+                                {
+                                    "id": 6583202,
+                                    "name": "Bauteilname",
+                                    "code": "01",
+                                    "description": null,
+                                    "datatype": "Property",
+                                    "parent_id": 6583195,
+                                    "template_id": 6378179,
+                                    "updated_at": "2022-08-26T10:35:06.468+02:00",
+                                    "unit": "Kennzeichen",
+                                    "unit_reference": "Datatypes.IfcLabel"
+                                },
+                                {
+                                    "id": 6583205,
+                                    "name": "Typ",
+                                    "code": "02",
+                                    "description": null,
+                                    "datatype": "Property",
+                                    "parent_id": 6583195,
+                                    "template_id": 6378180,
+                                    "updated_at": "2022-08-26T10:35:06.477+02:00",
+                                    "unit": "Kennzeichen",
+                                    "unit_reference": "Datatypes.IfcLabel"
+                                }
+                            ]
+                        },
+                        {
+                            "id": 6583206,
+                            "name": "gemeinsame Eigenschaften (IFC)",
+                            "code": "01-02",
+                            "description": "Gemeinsame IFC Eigenschaften",
+                            "datatype": "Group",
+                            "parent_id": 6583190,
+                            "template_id": 6378131,
+                            "updated_at": "2022-08-26T10:35:06.482+02:00",
+                            "child_concept": [
+                                {
+                                    "id": 6583208,
+                                    "name": "Rauchschutz",
+                                    "code": null,
+                                    "description": "Rauchschutz nach DIN 18095 / EN 16034-3",
+                                    "datatype": "Property",
+                                    "parent_id": 6583206,
+                                    "template_id": 6378183,
+                                    "updated_at": "2022-08-26T10:35:06.487+02:00",
+                                    "unit": "Wahr/Falsch",
+                                    "unit_reference": "Datatypes.IfcBoolean"
+                                },
+                                {
+                                    "id": 6583210,
+                                    "name": "Wärmedurchgangskoeffizient (U-Wert)",
+                                    "code": null,
+                                    "description": "Wärmedurchgangskoeffizient (U-Wert) der Materialschichten. Hier der Gesamtwärmedurchgangskoeffizient der Bekleidung (für alle Schichten).",
+                                    "datatype": "Property",
+                                    "parent_id": 6583206,
+                                    "template_id": 6378185,
+                                    "updated_at": "2022-08-26T10:35:06.494+02:00",
+                                    "unit": "Wärmedurchgängigkeit",
+                                    "unit_reference": "Measurements.IfcThermalTransmittanceMeasure"
+                                },
+                                {
+                                    "id": 6583211,
+                                    "name": "Schallschutzklasse",
+                                    "code": null,
+                                    "description": "Schallschutzklasse gemäß der nationalen oder regionalen Schallschutzverordnung DIN 4109",
+                                    "datatype": "Property",
+                                    "parent_id": 6583206,
+                                    "template_id": 6378184,
+                                    "updated_at": "2022-08-26T10:35:06.500+02:00",
+                                    "unit": "Kennzeichen",
+                                    "unit_reference": "Datatypes.IfcLabel",
+                                    "child_concept": [
+                                        {
+                                            "id": 6583212,
+                                            "name": "1",
+                                            "code": "00",
+                                            "description": null,
+                                            "datatype": "Restriction",
+                                            "parent_id": 6583211,
+                                            "template_id": 6378221,
+                                            "updated_at": "2022-08-26T10:35:06.505+02:00"
+                                        },
+                                        {
+                                            "id": 6583214,
+                                            "name": "6",
+                                            "code": "05",
+                                            "description": null,
+                                            "datatype": "Restriction",
+                                            "parent_id": 6583211,
+                                            "template_id": 6378226,
+                                            "updated_at": "2022-08-26T10:35:06.509+02:00"
+                                        },
+                                        {
+                                            "id": 6583215,
+                                            "name": "4",
+                                            "code": "03",
+                                            "description": null,
+                                            "datatype": "Restriction",
+                                            "parent_id": 6583211,
+                                            "template_id": 6378224,
+                                            "updated_at": "2022-08-26T10:35:06.512+02:00"
+                                        },
+                                        {
+                                            "id": 6583217,
+                                            "name": "2",
+                                            "code": "01",
+                                            "description": null,
+                                            "datatype": "Restriction",
+                                            "parent_id": 6583211,
+                                            "template_id": 6378222,
+                                            "updated_at": "2022-08-26T10:35:06.516+02:00"
+                                        },
+                                        {
+                                            "id": 6583219,
+                                            "name": "3",
+                                            "code": "02",
+                                            "description": null,
+                                            "datatype": "Restriction",
+                                            "parent_id": 6583211,
+                                            "template_id": 6378223,
+                                            "updated_at": "2022-08-26T10:35:06.520+02:00"
+                                        },
+                                        {
+                                            "id": 6583221,
+                                            "name": "5",
+                                            "code": "04",
+                                            "description": null,
+                                            "datatype": "Restriction",
+                                            "parent_id": 6583211,
+                                            "template_id": 6378225,
+                                            "updated_at": "2022-08-26T10:35:06.524+02:00"
+                                        }
+                                    ]
+                                },
+                                {
+                                    "id": 6583223,
+                                    "name": "Feuerwiderstandsklasse",
+                                    "code": null,
+                                    "description": "Feuerwiderstandsklasse gemäß der nationalen oder regionalen Brandschutzverordnung.",
+                                    "datatype": "Property",
+                                    "parent_id": 6583206,
+                                    "template_id": 6378182,
+                                    "updated_at": "2022-08-26T10:35:06.529+02:00",
+                                    "unit": "Kennzeichen",
+                                    "unit_reference": "Datatypes.IfcLabel",
+                                    "child_concept": [
+                                        {
+                                            "id": 6583225,
+                                            "name": "F30",
+                                            "code": null,
+                                            "description": null,
+                                            "datatype": "Restriction",
+                                            "parent_id": 6583223,
+                                            "template_id": 6378218,
+                                            "updated_at": "2022-08-26T10:35:06.535+02:00"
+                                        },
+                                        {
+                                            "id": 6583227,
+                                            "name": "F90",
+                                            "code": null,
+                                            "description": null,
+                                            "datatype": "Restriction",
+                                            "parent_id": 6583223,
+                                            "template_id": 6378220,
+                                            "updated_at": "2022-08-26T10:35:06.539+02:00"
+                                        },
+                                        {
+                                            "id": 6583228,
+                                            "name": "F60",
+                                            "code": null,
+                                            "description": null,
+                                            "datatype": "Restriction",
+                                            "parent_id": 6583223,
+                                            "template_id": 6378219,
+                                            "updated_at": "2022-08-26T10:35:06.545+02:00"
+                                        }
+                                    ]
+                                }
+                            ]
+                        },
+                        {
+                            "id": 6583229,
+                            "name": "spezieller Eigenschaftssatz Brandschutz",
+                            "code": "05-02",
+                            "description": null,
+                            "datatype": "Group",
+                            "parent_id": 6583190,
+                            "template_id": 6378135,
+                            "updated_at": "2022-08-26T10:35:06.551+02:00",
+                            "child_concept": [
+                                {
+                                    "id": 6583230,
+                                    "name": "Rauchabzugsfunktion Bauteil",
+                                    "code": null,
+                                    "description": "z.B. Dachoberlichter, Fassadenelemente, Fenster oder spezielle Klappen. Abhängig von Brandschutzkonzept.",
+                                    "datatype": "Property",
+                                    "parent_id": 6583229,
+                                    "template_id": 6378208,
+                                    "updated_at": "2022-08-26T10:35:06.557+02:00",
+                                    "unit": "Kennzeichen",
+                                    "unit_reference": "Datatypes.IfcLabel"
+                                },
+                                {
+                                    "id": 6583231,
+                                    "name": "Brandfallsteuerung",
+                                    "code": null,
+                                    "description": "Türschliesser, Rauchklappen in Treppenhäusern etc.",
+                                    "datatype": "Property",
+                                    "parent_id": 6583229,
+                                    "template_id": 6378207,
+                                    "updated_at": "2022-08-26T10:35:06.565+02:00",
+                                    "unit": "Kennzeichen",
+                                    "unit_reference": "Datatypes.IfcLabel"
+                                }
+                            ]
+                        },
+                        {
+                            "id": 6583232,
+                            "name": "Geometrie Türen",
+                            "code": "00",
+                            "description": "-",
+                            "datatype": "Group",
+                            "parent_id": 6583190,
+                            "template_id": 6378128,
+                            "updated_at": "2022-08-26T10:35:06.573+02:00",
+                            "child_concept": [
+                                {
+                                    "id": 6583233,
+                                    "name": "LOG 400 - Tür",
+                                    "code": null,
+                                    "description": "Die Türen enthalten alle Details zur Fertigung. Alle Komponenten, Anschlüsse und die Details für die Vorfertigung und Montage werden detailliert modelliert. Ggf. werden die BIM Objekte der Hersteller verwendet.",
+                                    "datatype": "Geometry",
+                                    "parent_id": 6583232,
+                                    "template_id": 6378176,
+                                    "updated_at": "2022-08-26T10:35:06.578+02:00"
+                                },
+                                {
+                                    "id": 6583234,
+                                    "name": "LOG 200 - Tür",
+                                    "code": null,
+                                    "description": "Die Türen werden in ihrer ungefähren Form, Größe und Lage modelliert. Die Öffnungsart und Richtung wird angegeben.",
+                                    "datatype": "Geometry",
+                                    "parent_id": 6583232,
+                                    "template_id": 6378174,
+                                    "updated_at": "2022-08-26T10:35:06.586+02:00"
+                                },
+                                {
+                                    "id": 6583235,
+                                    "name": "LOG 500 - Tür",
+                                    "code": null,
+                                    "description": "Vollständige Modellierung der Türen im konkreten, gebauten Zustand. Sie sind Teil der Objektdokumentation und zur Archivierung des Bestands.",
+                                    "datatype": "Geometry",
+                                    "parent_id": 6583232,
+                                    "template_id": 6378177,
+                                    "updated_at": "2022-08-26T10:35:06.591+02:00"
+                                },
+                                {
+                                    "id": 6583236,
+                                    "name": "LOG 300 - Tür",
+                                    "code": null,
+                                    "description": "Die Türen werden in ihrer genauen Form, Größe, mit sämtlichen Rahmendetails und Öffnungsflügeln modelliert.",
+                                    "datatype": "Geometry",
+                                    "parent_id": 6583232,
+                                    "template_id": 6378175,
+                                    "updated_at": "2022-08-26T10:35:06.597+02:00"
+                                },
+                                {
+                                    "id": 6583237,
+                                    "name": "LOG 100 - Tür",
+                                    "code": null,
+                                    "description": "Die Position der Türen wird entweder schematisch oder geometrisch mit einer ungefähren, noch flexiblen Geometrie dargestellt. Oft repräsentiert ein Massenmodell das gesamte Bauwerk in dieser Planungsphase.",
+                                    "datatype": "Geometry",
+                                    "parent_id": 6583232,
+                                    "template_id": 6378173,
+                                    "updated_at": "2022-08-26T10:35:06.603+02:00"
+                                }
+                            ]
+                        },
+                        {
+                            "id": 6583238,
+                            "name": "spezieller Eigenschaftssatz Sicherheit",
+                            "code": "05-07",
+                            "description": null,
+                            "datatype": "Group",
+                            "parent_id": 6583190,
+                            "template_id": 6378136,
+                            "updated_at": "2022-08-26T10:35:06.608+02:00",
+                            "child_concept": [
+                                {
+                                    "id": 6583239,
+                                    "name": "VSG Fläche",
+                                    "code": null,
+                                    "description": "Fläche des VS-Glases",
+                                    "datatype": "Property",
+                                    "parent_id": 6583238,
+                                    "template_id": 6378209,
+                                    "updated_at": "2022-08-26T10:35:06.614+02:00",
+                                    "unit": "Fläche",
+                                    "unit_reference": "Measurements.IfcAreaMeasure"
+                                },
+                                {
+                                    "id": 6583240,
+                                    "name": "VSG Kennzeichnung",
+                                    "code": null,
+                                    "description": "Markierung und Typenbezeichnungen des VS-Glases",
+                                    "datatype": "Property",
+                                    "parent_id": 6583238,
+                                    "template_id": 6378210,
+                                    "updated_at": "2022-08-26T10:35:06.621+02:00",
+                                    "unit": "Kennzeichen",
+                                    "unit_reference": "Datatypes.IfcLabel"
+                                }
+                            ]
+                        },
+                        {
+                            "id": 6583241,
+                            "name": "gemeinsame Eigenschaften Bauteile (Modelle)",
+                            "code": "01-01-01",
+                            "description": "Kopfdaten für alle Modellelemente",
+                            "datatype": "Group",
+                            "parent_id": 6583190,
+                            "template_id": 6378129,
+                            "updated_at": "2022-08-26T10:35:06.629+02:00",
+                            "child_concept": [
+                                {
+                                    "id": 6583242,
+                                    "name": "Kostengruppe DIN 276-+",
+                                    "code": "03",
+                                    "description": null,
+                                    "datatype": "Property",
+                                    "parent_id": 6583241,
+                                    "template_id": 6378178,
+                                    "updated_at": "2022-08-26T10:35:06.635+02:00",
+                                    "unit": "Kennzeichen",
+                                    "unit_reference": "Datatypes.IfcLabel"
+                                }
+                            ]
+                        },
+                        {
+                            "id": 6583243,
+                            "name": "spezieller Eigenschaftssatz Türen (Modelle)",
+                            "code": "03-05-01",
+                            "description": null,
+                            "datatype": "Group",
+                            "parent_id": 6583190,
+                            "template_id": 6378133,
+                            "updated_at": "2022-08-26T10:35:06.643+02:00",
+                            "child_concept": [
+                                {
+                                    "id": 6583244,
+                                    "name": "Türschliesser",
+                                    "code": null,
+                                    "description": "Ausstattung von Türen: Türschliesser.",
+                                    "datatype": "Property",
+                                    "parent_id": 6583243,
+                                    "template_id": 6378197,
+                                    "updated_at": "2022-08-26T10:35:06.649+02:00",
+                                    "unit": "Wahr/Falsch",
+                                    "unit_reference": "Datatypes.IfcBoolean"
+                                },
+                                {
+                                    "id": 6583245,
+                                    "name": "Obentürschließer",
+                                    "code": null,
+                                    "description": null,
+                                    "datatype": "Property",
+                                    "parent_id": 6583243,
+                                    "template_id": 6378193,
+                                    "updated_at": "2022-08-26T10:35:06.656+02:00",
+                                    "unit": "Wahr/Falsch",
+                                    "unit_reference": "Datatypes.IfcBoolean"
+                                },
+                                {
+                                    "id": 6583246,
+                                    "name": "Durchgangshöhe",
+                                    "code": null,
+                                    "description": "Türliste, Detailangabe",
+                                    "datatype": "Property",
+                                    "parent_id": 6583243,
+                                    "template_id": 6378191,
+                                    "updated_at": "2022-08-26T10:35:06.665+02:00",
+                                    "unit": "Länge.m",
+                                    "unit_reference": "Measurements.IfcLengthMeasure.METRE"
+                                },
+                                {
+                                    "id": 6583247,
+                                    "name": "Türhöhe Rohbaumaß",
+                                    "code": null,
+                                    "description": "Türliste, Detailangabe",
+                                    "datatype": "Property",
+                                    "parent_id": 6583243,
+                                    "template_id": 6378196,
+                                    "updated_at": "2022-08-26T10:35:06.674+02:00",
+                                    "unit": "Länge.m",
+                                    "unit_reference": "Measurements.IfcLengthMeasure.METRE"
+                                },
+                                {
+                                    "id": 6583248,
+                                    "name": "Durchgangsbreite",
+                                    "code": null,
+                                    "description": "Durchgangsbreite von Türen",
+                                    "datatype": "Property",
+                                    "parent_id": 6583243,
+                                    "template_id": 6378190,
+                                    "updated_at": "2022-08-26T10:35:06.681+02:00",
+                                    "unit": "Länge.m",
+                                    "unit_reference": "Measurements.IfcLengthMeasure.METRE"
+                                },
+                                {
+                                    "id": 6583249,
+                                    "name": "Türblattstärke",
+                                    "code": null,
+                                    "description": "Türliste, Detailangabe",
+                                    "datatype": "Property",
+                                    "parent_id": 6583243,
+                                    "template_id": 6378195,
+                                    "updated_at": "2022-08-26T10:35:06.688+02:00",
+                                    "unit": "Länge.m",
+                                    "unit_reference": "Measurements.IfcLengthMeasure.METRE"
+                                },
+                                {
+                                    "id": 6583250,
+                                    "name": "Zargentiefe",
+                                    "code": null,
+                                    "description": "Türliste, Detailangabe",
+                                    "datatype": "Property",
+                                    "parent_id": 6583243,
+                                    "template_id": 6378200,
+                                    "updated_at": "2022-08-26T10:35:06.694+02:00",
+                                    "unit": "Länge.m",
+                                    "unit_reference": "Measurements.IfcLengthMeasure.METRE"
+                                },
+                                {
+                                    "id": 6583251,
+                                    "name": "Bodenschwelle",
+                                    "code": null,
+                                    "description": "Eigenschaft Bodenschwelle",
+                                    "datatype": "Property",
+                                    "parent_id": 6583243,
+                                    "template_id": 6378189,
+                                    "updated_at": "2022-08-26T10:35:06.700+02:00",
+                                    "unit": "Kennzeichen",
+                                    "unit_reference": "Datatypes.IfcLabel",
+                                    "child_concept": [
+                                        {
+                                            "id": 6583252,
+                                            "name": "mit Stufe",
+                                            "code": "01",
+                                            "description": null,
+                                            "datatype": "Restriction",
+                                            "parent_id": 6583251,
+                                            "template_id": 6378233,
+                                            "updated_at": "2022-08-26T10:35:06.706+02:00"
+                                        },
+                                        {
+                                            "id": 6583253,
+                                            "name": "stufenlos",
+                                            "code": "00",
+                                            "description": null,
+                                            "datatype": "Restriction",
+                                            "parent_id": 6583251,
+                                            "template_id": 6378232,
+                                            "updated_at": "2022-08-26T10:35:06.710+02:00"
+                                        }
+                                    ]
+                                },
+                                {
+                                    "id": 6583254,
+                                    "name": "Zargenstärke",
+                                    "code": null,
+                                    "description": "Türliste, Detailangabe",
+                                    "datatype": "Property",
+                                    "parent_id": 6583243,
+                                    "template_id": 6378199,
+                                    "updated_at": "2022-08-26T10:35:06.715+02:00",
+                                    "unit": "Länge.m",
+                                    "unit_reference": "Measurements.IfcLengthMeasure.METRE"
+                                },
+                                {
+                                    "id": 6583255,
+                                    "name": "Zargenart",
+                                    "code": null,
+                                    "description": "Türliste, Detailangabe",
+                                    "datatype": "Property",
+                                    "parent_id": 6583243,
+                                    "template_id": 6378198,
+                                    "updated_at": "2022-08-26T10:35:06.724+02:00",
+                                    "unit": "Kennzeichen",
+                                    "unit_reference": "Datatypes.IfcLabel"
+                                },
+                                {
+                                    "id": 6583256,
+                                    "name": "Fluchtweg Aussentür",
+                                    "code": null,
+                                    "description": "nicht abschliessbar, mit Notausgangsverschluss. Zu klären ist, wie die Türe trotz Fluchtfunktion abgeschlossen werden kann.",
+                                    "datatype": "Property",
+                                    "parent_id": 6583243,
+                                    "template_id": 6378192,
+                                    "updated_at": "2022-08-26T10:35:06.733+02:00",
+                                    "unit": "Kennzeichen",
+                                    "unit_reference": "Datatypes.IfcLabel"
+                                },
+                                {
+                                    "id": 6583257,
+                                    "name": "Offenhaltung",
+                                    "code": null,
+                                    "description": null,
+                                    "datatype": "Property",
+                                    "parent_id": 6583243,
+                                    "template_id": 6378194,
+                                    "updated_at": "2022-08-26T10:35:06.741+02:00",
+                                    "unit": "Wahr/Falsch",
+                                    "unit_reference": "Datatypes.IfcBoolean"
+                                },
+                                {
+                                    "id": 6583258,
+                                    "name": "Art der Tür",
+                                    "code": null,
+                                    "description": null,
+                                    "datatype": "Property",
+                                    "parent_id": 6583243,
+                                    "template_id": 6378188,
+                                    "updated_at": "2022-08-26T10:35:06.749+02:00",
+                                    "unit": "Kennzeichen",
+                                    "unit_reference": "Datatypes.IfcLabel",
+                                    "child_concept": [
+                                        {
+                                            "id": 6583259,
+                                            "name": "Wohnungstür",
+                                            "code": null,
+                                            "description": null,
+                                            "datatype": "Restriction",
+                                            "parent_id": 6583258,
+                                            "template_id": 6378230,
+                                            "updated_at": "2022-08-26T10:35:06.757+02:00"
+                                        },
+                                        {
+                                            "id": 6583260,
+                                            "name": "Fenster/Balkontür",
+                                            "code": null,
+                                            "description": null,
+                                            "datatype": "Restriction",
+                                            "parent_id": 6583258,
+                                            "template_id": 6378227,
+                                            "updated_at": "2022-08-26T10:35:06.762+02:00"
+                                        },
+                                        {
+                                            "id": 6583261,
+                                            "name": "Technische Türen",
+                                            "code": null,
+                                            "description": "z.B. Lift, Schaltschrank,..",
+                                            "datatype": "Restriction",
+                                            "parent_id": 6583258,
+                                            "template_id": 6378229,
+                                            "updated_at": "2022-08-26T10:35:06.768+02:00"
+                                        },
+                                        {
+                                            "id": 6583262,
+                                            "name": "Zimmertür",
+                                            "code": null,
+                                            "description": null,
+                                            "datatype": "Restriction",
+                                            "parent_id": 6583258,
+                                            "template_id": 6378231,
+                                            "updated_at": "2022-08-26T10:35:06.774+02:00"
+                                        },
+                                        {
+                                            "id": 6583263,
+                                            "name": "Hauseingangstür",
+                                            "code": null,
+                                            "description": null,
+                                            "datatype": "Restriction",
+                                            "parent_id": 6583258,
+                                            "template_id": 6378228,
+                                            "updated_at": "2022-08-26T10:35:06.780+02:00"
+                                        }
+                                    ]
+                                },
+                                {
+                                    "id": 6583264,
+                                    "name": "Zulassungsnummer",
+                                    "code": null,
+                                    "description": "Türliste, Detailangabe",
+                                    "datatype": "Property",
+                                    "parent_id": 6583243,
+                                    "template_id": 6378201,
+                                    "updated_at": "2022-08-26T10:35:06.787+02:00",
+                                    "unit": "Kennzeichen",
+                                    "unit_reference": "Datatypes.IfcLabel"
+                                }
+                            ]
+                        },
+                        {
+                            "id": 6583265,
+                            "name": "spezieller Eigenschaftssatz Wände, Türen, Fenster, Fassaden",
+                            "code": "03-01-01",
+                            "description": null,
+                            "datatype": "Group",
+                            "parent_id": 6583190,
+                            "template_id": 6378132,
+                            "updated_at": "2022-08-26T10:35:06.795+02:00",
+                            "child_concept": [
+                                {
+                                    "id": 6583266,
+                                    "name": "Breite Rohbau",
+                                    "code": null,
+                                    "description": "Bauteilbreite Rohbaumaß",
+                                    "datatype": "Property",
+                                    "parent_id": 6583265,
+                                    "template_id": 6378186,
+                                    "updated_at": "2022-08-26T10:35:06.801+02:00",
+                                    "unit": "Länge.m",
+                                    "unit_reference": "Measurements.IfcLengthMeasure.METRE"
+                                },
+                                {
+                                    "id": 6583267,
+                                    "name": "Höhe Rohbau",
+                                    "code": null,
+                                    "description": "Bauteilhöhe Rohbaumaß",
+                                    "datatype": "Property",
+                                    "parent_id": 6583265,
+                                    "template_id": 6378187,
+                                    "updated_at": "2022-08-26T10:35:06.810+02:00",
+                                    "unit": "Länge.m",
+                                    "unit_reference": "Measurements.IfcLengthMeasure.METRE"
+                                }
+                            ]
+                        },
+                        {
+                            "id": 6583268,
+                            "name": "spezieller Eigenschaftssatz Türen, Fenster",
+                            "code": "03-05-03",
+                            "description": null,
+                            "datatype": "Group",
+                            "parent_id": 6583190,
+                            "template_id": 6378134,
+                            "updated_at": "2022-08-26T10:35:06.817+02:00",
+                            "child_concept": [
+                                {
+                                    "id": 6583269,
+                                    "name": "Anzahl der Scheiben",
+                                    "code": null,
+                                    "description": null,
+                                    "datatype": "Property",
+                                    "parent_id": 6583268,
+                                    "template_id": 6378202,
+                                    "updated_at": "2022-08-26T10:35:06.824+02:00",
+                                    "unit": "ganze Zahl",
+                                    "unit_reference": "Datatypes.IfcInteger"
+                                },
+                                {
+                                    "id": 6583270,
+                                    "name": "Einbruchschutz",
+                                    "code": null,
+                                    "description": "Widerstandsklassen – Einbruchhemmende Bauteile nach DIN EN 1627",
+                                    "datatype": "Property",
+                                    "parent_id": 6583268,
+                                    "template_id": 6378204,
+                                    "updated_at": "2022-08-26T10:35:06.833+02:00",
+                                    "unit": "Kennzeichen",
+                                    "unit_reference": "Datatypes.IfcLabel",
+                                    "child_concept": [
+                                        {
+                                            "id": 6583271,
+                                            "name": "RC2",
+                                            "code": "02",
+                                            "description": null,
+                                            "datatype": "Restriction",
+                                            "parent_id": 6583270,
+                                            "template_id": 6378238,
+                                            "updated_at": "2022-08-26T10:35:06.842+02:00"
+                                        },
+                                        {
+                                            "id": 6583272,
+                                            "name": "RC2N",
+                                            "code": "01",
+                                            "description": null,
+                                            "datatype": "Restriction",
+                                            "parent_id": 6583270,
+                                            "template_id": 6378237,
+                                            "updated_at": "2022-08-26T10:35:06.847+02:00"
+                                        },
+                                        {
+                                            "id": 6583273,
+                                            "name": "RC3",
+                                            "code": "03",
+                                            "description": null,
+                                            "datatype": "Restriction",
+                                            "parent_id": 6583270,
+                                            "template_id": 6378239,
+                                            "updated_at": "2022-08-26T10:35:06.853+02:00"
+                                        },
+                                        {
+                                            "id": 6583274,
+                                            "name": "RC4",
+                                            "code": "04",
+                                            "description": null,
+                                            "datatype": "Restriction",
+                                            "parent_id": 6583270,
+                                            "template_id": 6378240,
+                                            "updated_at": "2022-08-26T10:35:06.899+02:00"
+                                        },
+                                        {
+                                            "id": 6583275,
+                                            "name": "RC1N",
+                                            "code": "00",
+                                            "description": null,
+                                            "datatype": "Restriction",
+                                            "parent_id": 6583270,
+                                            "template_id": 6378236,
+                                            "updated_at": "2022-08-26T10:35:06.905+02:00"
+                                        },
+                                        {
+                                            "id": 6583276,
+                                            "name": "RC6",
+                                            "code": "06",
+                                            "description": null,
+                                            "datatype": "Restriction",
+                                            "parent_id": 6583270,
+                                            "template_id": 6378242,
+                                            "updated_at": "2022-08-26T10:35:06.910+02:00"
+                                        },
+                                        {
+                                            "id": 6583277,
+                                            "name": "RC5",
+                                            "code": "05",
+                                            "description": null,
+                                            "datatype": "Restriction",
+                                            "parent_id": 6583270,
+                                            "template_id": 6378241,
+                                            "updated_at": "2022-08-26T10:35:06.916+02:00"
+                                        }
+                                    ]
+                                },
+                                {
+                                    "id": 6583278,
+                                    "name": "Aufschlagrichtung",
+                                    "code": null,
+                                    "description": "Aufschlagsrichtung von Türen und Fenstern",
+                                    "datatype": "Property",
+                                    "parent_id": 6583268,
+                                    "template_id": 6378203,
+                                    "updated_at": "2022-08-26T10:35:06.922+02:00",
+                                    "unit": "Kennzeichen",
+                                    "unit_reference": "Datatypes.IfcLabel",
+                                    "child_concept": [
+                                        {
+                                            "id": 6583279,
+                                            "name": "DIN R",
+                                            "code": "01",
+                                            "description": null,
+                                            "datatype": "Restriction",
+                                            "parent_id": 6583278,
+                                            "template_id": 6378235,
+                                            "updated_at": "2022-08-26T10:35:06.930+02:00"
+                                        },
+                                        {
+                                            "id": 6583280,
+                                            "name": "DIN L",
+                                            "code": "00",
+                                            "description": null,
+                                            "datatype": "Restriction",
+                                            "parent_id": 6583278,
+                                            "template_id": 6378234,
+                                            "updated_at": "2022-08-26T10:35:06.941+02:00"
+                                        }
+                                    ]
+                                },
+                                {
+                                    "id": 6583281,
+                                    "name": "Sturzhöhe",
+                                    "code": null,
+                                    "description": null,
+                                    "datatype": "Property",
+                                    "parent_id": 6583268,
+                                    "template_id": 6378206,
+                                    "updated_at": "2022-08-26T10:35:06.948+02:00",
+                                    "unit": "Länge",
+                                    "unit_reference": "Measurements.IfcLengthMeasure"
+                                },
+                                {
+                                    "id": 6583282,
+                                    "name": "Glasfläche",
+                                    "code": null,
+                                    "description": null,
+                                    "datatype": "Property",
+                                    "parent_id": 6583268,
+                                    "template_id": 6378205,
+                                    "updated_at": "2022-08-26T10:35:06.957+02:00",
+                                    "unit": "Fläche.m2",
+                                    "unit_reference": "Measurements.IfcAreaMeasure.SQUARE_METRE"
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "id": 6583283,
+                    "name": "Werkstatt",
+                    "code": null,
+                    "description": null,
+                    "datatype": "Type",
+                    "parent_id": 6583092,
+                    "template_id": 6378105,
+                    "updated_at": "2022-08-26T10:35:07.090+02:00",
+                    "map_item_id": 3309331,
+                    "map_item": "IfcSpace",
+                    "child_concept": [
+                        {
+                            "id": 6583284,
+                            "name": "gemeinsame Eigenschaften",
+                            "code": "01",
+                            "description": null,
+                            "datatype": "Group",
+                            "parent_id": 6583283,
+                            "template_id": 6378275,
+                            "updated_at": "2022-08-26T10:35:07.096+02:00",
+                            "child_concept": [
+                                {
+                                    "id": 6583288,
+                                    "name": "Bauteiltyp",
+                                    "code": null,
+                                    "description": null,
+                                    "datatype": "Property",
+                                    "parent_id": 6583284,
+                                    "template_id": 6378360,
+                                    "updated_at": "2022-08-26T10:35:07.152+02:00",
+                                    "unit": "Identifizierungszeichen",
+                                    "unit_reference": "Datatypes.IfcIdentifier"
+                                },
+                                {
+                                    "id": 6583285,
+                                    "name": "Außenbauteil",
+                                    "code": null,
+                                    "description": null,
+                                    "datatype": "Property",
+                                    "parent_id": 6583284,
+                                    "template_id": 6378359,
+                                    "updated_at": "2022-08-26T10:35:07.101+02:00",
+                                    "unit": "Wahr/Falsch",
+                                    "unit_reference": "Datatypes.IfcBoolean"
+                                },
+                                {
+                                    "id": 6583286,
+                                    "name": "Raumname",
+                                    "code": null,
+                                    "description": null,
+                                    "datatype": "Property",
+                                    "parent_id": 6583284,
+                                    "template_id": 6378149,
+                                    "updated_at": "2022-08-26T10:35:07.114+02:00",
+                                    "unit": "Kennzeichen",
+                                    "unit_reference": "Datatypes.IfcLabel",
+                                    "map_item_id": 3123976,
+                                    "map_item": "IfcSpatialElement Attributes.LongName"
+                                },
+                                {
+                                    "id": 6583287,
+                                    "name": "Tragendes Bauteil",
+                                    "code": null,
+                                    "description": null,
+                                    "datatype": "Property",
+                                    "parent_id": 6583284,
+                                    "template_id": 6378362,
+                                    "updated_at": "2022-08-26T10:35:07.134+02:00",
+                                    "unit": "Wahr/Falsch",
+                                    "unit_reference": "Datatypes.IfcBoolean"
+                                },
+                                {
+                                    "id": 6583289,
+                                    "name": "Spannweite",
+                                    "code": null,
+                                    "description": null,
+                                    "datatype": "Property",
+                                    "parent_id": 6583284,
+                                    "template_id": 6519819,
+                                    "updated_at": "2022-08-26T10:35:07.159+02:00",
+                                    "unit": "Länge (positiv, \u003e0)",
+                                    "unit_reference": "Measurements.IfcPositiveLengthMeasure"
+                                },
+                                {
+                                    "id": 6583290,
+                                    "name": "Wärmedurchgangskoeffizient  (U-Wert)",
+                                    "code": null,
+                                    "description": null,
+                                    "datatype": "Property",
+                                    "parent_id": 6583284,
+                                    "template_id": 6378363,
+                                    "updated_at": "2022-08-26T10:35:07.165+02:00",
+                                    "unit": "Wärmedurchgängigkeit",
+                                    "unit_reference": "Measurements.IfcThermalTransmittanceMeasure"
+                                },
+                                {
+                                    "id": 6583291,
+                                    "name": "Testeigenschaft",
+                                    "code": null,
+                                    "description": null,
+                                    "datatype": "Property",
+                                    "parent_id": 6583284,
+                                    "template_id": 6519820,
+                                    "updated_at": "2022-08-26T10:35:07.176+02:00",
+                                    "unit": "Kennzeichen",
+                                    "unit_reference": "Datatypes.IfcLabel"
+                                },
+                                {
+                                    "id": 6583292,
+                                    "name": "Feuerwiderstandsklasse",
+                                    "code": null,
+                                    "description": null,
+                                    "datatype": "Property",
+                                    "parent_id": 6583284,
+                                    "template_id": 6378361,
+                                    "updated_at": "2022-08-26T10:35:07.186+02:00",
+                                    "unit": "Kennzeichen",
+                                    "unit_reference": "Datatypes.IfcLabel",
+                                    "child_concept": [
+                                        {
+                                            "id": 6583293,
+                                            "name": "F60",
+                                            "code": null,
+                                            "description": null,
+                                            "datatype": "Restriction",
+                                            "parent_id": 6583292,
+                                            "template_id": 6378419,
+                                            "updated_at": "2022-08-26T10:35:07.202+02:00"
+                                        },
+                                        {
+                                            "id": 6583294,
+                                            "name": "F200",
+                                            "code": null,
+                                            "description": null,
+                                            "datatype": "Restriction",
+                                            "parent_id": 6583292,
+                                            "template_id": 6519804,
+                                            "updated_at": "2022-08-26T10:35:07.212+02:00"
+                                        },
+                                        {
+                                            "id": 6583295,
+                                            "name": "70",
+                                            "code": null,
+                                            "description": null,
+                                            "datatype": "Restriction",
+                                            "parent_id": 6583292,
+                                            "template_id": 6519802,
+                                            "updated_at": "2022-08-26T10:35:07.225+02:00"
+                                        },
+                                        {
+                                            "id": 6583296,
+                                            "name": "ABC",
+                                            "code": null,
+                                            "description": null,
+                                            "datatype": "Restriction",
+                                            "parent_id": 6583292,
+                                            "template_id": 6519803,
+                                            "updated_at": "2022-08-26T10:35:07.232+02:00"
+                                        },
+                                        {
+                                            "id": 6583297,
+                                            "name": "F30",
+                                            "code": null,
+                                            "description": null,
+                                            "datatype": "Restriction",
+                                            "parent_id": 6583292,
+                                            "template_id": 6378418,
+                                            "updated_at": "2022-08-26T10:35:07.248+02:00"
+                                        },
+                                        {
+                                            "id": 6583298,
+                                            "name": "F90",
+                                            "code": null,
+                                            "description": null,
+                                            "datatype": "Restriction",
+                                            "parent_id": 6583292,
+                                            "template_id": 6378420,
+                                            "updated_at": "2022-08-26T10:35:07.251+02:00"
+                                        }
+                                    ]
+                                }
+                            ]
+                        },
+                        {
+                            "id": 6583299,
+                            "name": "CKs Eigenschaften (Konzeptname!)",
+                            "code": null,
+                            "description": null,
+                            "datatype": "Group",
+                            "parent_id": 6583283,
+                            "template_id": 6378110,
+                            "updated_at": "2022-08-26T10:35:07.256+02:00",
+                            "map_item_id": 3123981,
+                            "map_item": "CKs Eigenschaften",
+                            "child_concept": [
+                                {
+                                    "id": 6583300,
+                                    "name": "Raumnummer",
+                                    "code": null,
+                                    "description": null,
+                                    "datatype": "Property",
+                                    "parent_id": 6583299,
+                                    "template_id": 6378150,
+                                    "updated_at": "2022-08-26T10:35:07.265+02:00",
+                                    "unit": "Kennzeichen",
+                                    "unit_reference": "Datatypes.IfcLabel",
+                                    "map_item_id": 3123977,
+                                    "map_item": "IfcElement Attributes.Name"
+                                },
+                                {
+                                    "id": 6583301,
+                                    "name": "Test Bauteil",
+                                    "code": null,
+                                    "description": null,
+                                    "datatype": "Property",
+                                    "parent_id": 6583299,
+                                    "template_id": 6378146,
+                                    "updated_at": "2022-08-26T10:35:07.274+02:00",
+                                    "unit": "Wahr/Falsch",
+                                    "unit_reference": "Datatypes.IfcBoolean",
+                                    "map_item_id": 3123922,
+                                    "map_item": "#.Test Bauteil"
+                                },
+                                {
+                                    "id": 6583302,
+                                    "name": "AttributName",
+                                    "code": null,
+                                    "description": null,
+                                    "datatype": "Property",
+                                    "parent_id": 6583299,
+                                    "template_id": 6378143,
+                                    "updated_at": "2022-08-26T10:35:07.285+02:00",
+                                    "unit": "Kennzeichen",
+                                    "unit_reference": "Datatypes.IfcLabel",
+                                    "map_item_id": 3123958,
+                                    "map_item": "IfcElement Attributes.Name"
+                                },
+                                {
+                                    "id": 6583303,
+                                    "name": "CKBauteiltyp",
+                                    "code": null,
+                                    "description": null,
+                                    "datatype": "Property",
+                                    "parent_id": 6583299,
+                                    "template_id": 6378144,
+                                    "updated_at": "2022-08-26T10:35:07.296+02:00",
+                                    "unit": "Kennzeichen",
+                                    "unit_reference": "Datatypes.IfcLabel",
+                                    "map_item_id": 3124009,
+                                    "map_item": "#.CKBauteiltyp",
+                                    "child_concept": [
+                                        {
+                                            "id": 6583304,
+                                            "name": "Testwert",
+                                            "code": "1212",
+                                            "description": null,
+                                            "datatype": "Restriction",
+                                            "parent_id": 6583303,
+                                            "template_id": 6470184,
+                                            "updated_at": "2022-08-26T10:35:07.304+02:00"
+                                        }
+                                    ]
+                                },
+                                {
+                                    "id": 6583305,
+                                    "name": "CKsBeschreibung",
+                                    "code": null,
+                                    "description": null,
+                                    "datatype": "Property",
+                                    "parent_id": 6583299,
+                                    "template_id": 6378145,
+                                    "updated_at": "2022-08-26T10:35:07.310+02:00",
+                                    "unit": "Kennzeichen",
+                                    "unit_reference": "Datatypes.IfcLabel",
+                                    "map_item_id": 3123960,
+                                    "map_item": "IfcElement Attributes.Description"
+                                },
+                                {
+                                    "id": 6583306,
+                                    "name": "Testwert",
+                                    "code": null,
+                                    "description": null,
+                                    "datatype": "Property",
+                                    "parent_id": 6583299,
+                                    "template_id": 6378154,
+                                    "updated_at": "2022-08-26T10:35:07.321+02:00",
+                                    "unit": "Länge (nicht-negativ, \u003e=0).m",
+                                    "unit_reference": "Measurements.IfcNonNegativeLengthMeasure.METRE",
+                                    "map_item_id": 3124007,
+                                    "map_item": "#.Testwert"
+                                }
+                            ]
+                        },
+                        {
+                            "id": 6583307,
+                            "name": "Kopfdaten",
+                            "code": null,
+                            "description": null,
+                            "datatype": "Group",
+                            "parent_id": 6583283,
+                            "template_id": 6461821,
+                            "updated_at": "2022-08-26T10:35:07.329+02:00",
+                            "child_concept": [
+                                {
+                                    "id": 6583308,
+                                    "name": "Raumhöhe",
+                                    "code": "123",
+                                    "description": null,
+                                    "datatype": "Property",
+                                    "parent_id": 6583307,
+                                    "template_id": 6461825,
+                                    "updated_at": "2022-08-26T10:35:07.332+02:00",
+                                    "unit": "Kennzeichen",
+                                    "unit_reference": "Datatypes.IfcLabel",
+                                    "map_item_id": 3205235,
+                                    "map_item": "#.Raumhöhe",
+                                    "child_concept": [
+                                        {
+                                            "id": 6583309,
+                                            "name": "3 m",
+                                            "code": null,
+                                            "description": null,
+                                            "datatype": "Restriction",
+                                            "parent_id": 6583308,
+                                            "template_id": 6461832,
+                                            "updated_at": "2022-08-26T10:35:07.336+02:00"
+                                        }
+                                    ]
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "id": 6583093,
+                    "name": "Aussenwand tragend",
+                    "code": "2-01",
+                    "description": null,
+                    "datatype": "Type",
+                    "parent_id": 6583092,
+                    "template_id": 6378102,
+                    "updated_at": "2022-08-26T10:35:05.720+02:00",
+                    "map_item_id": 3309314,
+                    "map_item": "IfcWall.##.##.Pset_WallCommon.LoadBearing:True",
+                    "child_concept": [
+                        {
+                            "id": 6583095,
+                            "name": "gemeinsame Eigenschaften",
+                            "code": "01",
+                            "description": null,
+                            "datatype": "Group",
+                            "parent_id": 6583093,
+                            "template_id": 6378108,
+                            "updated_at": "2022-08-26T10:35:05.737+02:00",
+                            "child_concept": [
+                                {
+                                    "id": 6583097,
+                                    "name": "Außenbauteil",
+                                    "code": null,
+                                    "description": null,
+                                    "datatype": "Property",
+                                    "parent_id": 6583095,
+                                    "template_id": 6378137,
+                                    "updated_at": "2022-08-26T10:35:05.746+02:00",
+                                    "unit": "Wahr/Falsch",
+                                    "unit_reference": "Datatypes.IfcBoolean",
+                                    "map_item_id": 3123893,
+                                    "map_item": "*.IsExternal"
+                                },
+                                {
+                                    "id": 6583099,
+                                    "name": "Name",
+                                    "code": null,
+                                    "description": null,
+                                    "datatype": "Property",
+                                    "parent_id": 6583095,
+                                    "template_id": 6378153,
+                                    "updated_at": "2022-08-26T10:35:05.760+02:00",
+                                    "unit": "Kennzeichen",
+                                    "unit_reference": "Datatypes.IfcLabel",
+                                    "map_item_id": 3123983,
+                                    "map_item": "#.Name"
+                                },
+                                {
+                                    "id": 6583101,
+                                    "name": "Feuerwiderstandsklasse",
+                                    "code": null,
+                                    "description": null,
+                                    "datatype": "Property",
+                                    "parent_id": 6583095,
+                                    "template_id": 6378140,
+                                    "updated_at": "2022-08-26T10:35:05.769+02:00",
+                                    "unit": "Kennzeichen",
+                                    "unit_reference": "Datatypes.IfcLabel",
+                                    "map_item_id": 3123946,
+                                    "map_item": "*.FireRating",
+                                    "child_concept": [
+                                        {
+                                            "id": 6583104,
+                                            "name": "70",
+                                            "code": null,
+                                            "description": null,
+                                            "datatype": "Restriction",
+                                            "parent_id": 6583101,
+                                            "template_id": 6378215,
+                                            "updated_at": "2022-08-26T10:35:05.780+02:00"
+                                        },
+                                        {
+                                            "id": 6583106,
+                                            "name": "F200",
+                                            "code": null,
+                                            "description": null,
+                                            "datatype": "Restriction",
+                                            "parent_id": 6583101,
+                                            "template_id": 6519793,
+                                            "updated_at": "2022-08-26T10:35:05.785+02:00"
+                                        },
+                                        {
+                                            "id": 6583108,
+                                            "name": "F60",
+                                            "code": null,
+                                            "description": null,
+                                            "datatype": "Restriction",
+                                            "parent_id": 6583101,
+                                            "template_id": 6378212,
+                                            "updated_at": "2022-08-26T10:35:05.790+02:00"
+                                        },
+                                        {
+                                            "id": 6583110,
+                                            "name": "F90",
+                                            "code": null,
+                                            "description": null,
+                                            "datatype": "Restriction",
+                                            "parent_id": 6583101,
+                                            "template_id": 6378213,
+                                            "updated_at": "2022-08-26T10:35:05.796+02:00"
+                                        },
+                                        {
+                                            "id": 6583112,
+                                            "name": "ABC",
+                                            "code": null,
+                                            "description": null,
+                                            "datatype": "Restriction",
+                                            "parent_id": 6583101,
+                                            "template_id": 6378214,
+                                            "updated_at": "2022-08-26T10:35:05.801+02:00"
+                                        },
+                                        {
+                                            "id": 6583114,
+                                            "name": "F30",
+                                            "code": null,
+                                            "description": null,
+                                            "datatype": "Restriction",
+                                            "parent_id": 6583101,
+                                            "template_id": 6378211,
+                                            "updated_at": "2022-08-26T10:35:05.806+02:00"
+                                        }
+                                    ]
+                                },
+                                {
+                                    "id": 6583117,
+                                    "name": "Bauteiltyp",
+                                    "code": null,
+                                    "description": null,
+                                    "datatype": "Property",
+                                    "parent_id": 6583095,
+                                    "template_id": 6378139,
+                                    "updated_at": "2022-08-26T10:35:05.812+02:00",
+                                    "unit": "Identifizierungszeichen",
+                                    "unit_reference": "Datatypes.IfcIdentifier",
+                                    "map_item_id": 3123945,
+                                    "map_item": "*.Reference"
+                                },
+                                {
+                                    "id": 6583119,
+                                    "name": "Wärmedurchgangskoeffizient  (U-Wert)",
+                                    "code": null,
+                                    "description": null,
+                                    "datatype": "Property",
+                                    "parent_id": 6583095,
+                                    "template_id": 6378142,
+                                    "updated_at": "2022-08-26T10:35:05.819+02:00",
+                                    "unit": "Wärmedurchgängigkeit",
+                                    "unit_reference": "Measurements.IfcThermalTransmittanceMeasure",
+                                    "map_item_id": 3123948,
+                                    "map_item": "*.ThermalTransmittance"
+                                },
+                                {
+                                    "id": 6583122,
+                                    "name": "Spannweite",
+                                    "code": null,
+                                    "description": null,
+                                    "datatype": "Property",
+                                    "parent_id": 6583095,
+                                    "template_id": 6378141,
+                                    "updated_at": "2022-08-26T10:35:05.832+02:00",
+                                    "unit": "Länge (positiv, \u003e0)",
+                                    "unit_reference": "Measurements.IfcPositiveLengthMeasure",
+                                    "map_item_id": 3123947,
+                                    "map_item": "*.Span"
+                                },
+                                {
+                                    "id": 6583125,
+                                    "name": "Tragendes Bauteil",
+                                    "code": null,
+                                    "description": null,
+                                    "datatype": "Property",
+                                    "parent_id": 6583095,
+                                    "template_id": 6378138,
+                                    "updated_at": "2022-08-26T10:35:05.840+02:00",
+                                    "unit": "Wahr/Falsch",
+                                    "unit_reference": "Datatypes.IfcBoolean",
+                                    "map_item_id": 3123900,
+                                    "map_item": "*.LoadBearing"
+                                },
+                                {
+                                    "id": 6583128,
+                                    "name": "Testeigenschaft",
+                                    "code": null,
+                                    "description": null,
+                                    "datatype": "Property",
+                                    "parent_id": 6583095,
+                                    "template_id": 6519792,
+                                    "updated_at": "2022-08-26T10:35:05.850+02:00",
+                                    "unit": "Kennzeichen",
+                                    "unit_reference": "Datatypes.IfcLabel",
+                                    "map_item_id": 3274994,
+                                    "map_item": "#.Testeigenschaft"
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "id": 6583094,
+                    "name": "Balken / Unterzug",
+                    "code": "2-03",
+                    "description": null,
+                    "datatype": "Type",
+                    "parent_id": 6583092,
+                    "template_id": 6378109,
+                    "updated_at": "2022-08-26T10:35:05.728+02:00",
+                    "map_item_id": 3123925,
+                    "map_item": "IfcBeam",
+                    "child_concept": [
+                        {
+                            "id": 6583096,
+                            "name": "CKs Mengen Balken",
+                            "code": "02",
+                            "description": null,
+                            "datatype": "Group",
+                            "parent_id": 6583094,
+                            "template_id": 6378111,
+                            "updated_at": "2022-08-26T10:35:05.742+02:00",
+                            "map_item_id": 3124002,
+                            "map_item": "BaseQuantities",
+                            "child_concept": [
+                                {
+                                    "id": 6583098,
+                                    "name": "Fläche",
+                                    "code": null,
+                                    "description": "Fläche",
+                                    "datatype": "Property",
+                                    "parent_id": 6583096,
+                                    "template_id": 6378148,
+                                    "updated_at": "2022-08-26T10:35:05.750+02:00",
+                                    "unit": "Fläche",
+                                    "unit_reference": "Measurements.IfcAreaMeasure",
+                                    "map_item_id": 3309318,
+                                    "map_item": "Qto_BeamBaseQuantities.CrossSectionArea"
+                                },
+                                {
+                                    "id": 6583100,
+                                    "name": "Breite",
+                                    "code": null,
+                                    "description": "Breite",
+                                    "datatype": "Property",
+                                    "parent_id": 6583096,
+                                    "template_id": 6378147,
+                                    "updated_at": "2022-08-26T10:35:05.761+02:00",
+                                    "unit": "Länge",
+                                    "unit_reference": "Measurements.IfcLengthMeasure",
+                                    "map_item_id": 3309320,
+                                    "map_item": "BaseQuantities.Width"
+                                }
+                            ]
+                        },
+                        {
+                            "id": 6583102,
+                            "name": "gemeinsame Eigenschaften",
+                            "code": "01",
+                            "description": null,
+                            "datatype": "Group",
+                            "parent_id": 6583094,
+                            "template_id": 6378108,
+                            "updated_at": "2022-08-26T10:35:05.769+02:00",
+                            "child_concept": [
+                                {
+                                    "id": 6583103,
+                                    "name": "Spannweite",
+                                    "code": null,
+                                    "description": null,
+                                    "datatype": "Property",
+                                    "parent_id": 6583102,
+                                    "template_id": 6378141,
+                                    "updated_at": "2022-08-26T10:35:05.776+02:00",
+                                    "unit": "Länge (positiv, \u003e0)",
+                                    "unit_reference": "Measurements.IfcPositiveLengthMeasure",
+                                    "map_item_id": 3123947,
+                                    "map_item": "*.Span"
+                                },
+                                {
+                                    "id": 6583105,
+                                    "name": "Feuerwiderstandsklasse",
+                                    "code": null,
+                                    "description": null,
+                                    "datatype": "Property",
+                                    "parent_id": 6583102,
+                                    "template_id": 6378140,
+                                    "updated_at": "2022-08-26T10:35:05.781+02:00",
+                                    "unit": "Kennzeichen",
+                                    "unit_reference": "Datatypes.IfcLabel",
+                                    "map_item_id": 3123946,
+                                    "map_item": "*.FireRating",
+                                    "child_concept": [
+                                        {
+                                            "id": 6583107,
+                                            "name": "F200",
+                                            "code": null,
+                                            "description": null,
+                                            "datatype": "Restriction",
+                                            "parent_id": 6583105,
+                                            "template_id": 6519793,
+                                            "updated_at": "2022-08-26T10:35:05.787+02:00"
+                                        },
+                                        {
+                                            "id": 6583109,
+                                            "name": "F30",
+                                            "code": null,
+                                            "description": null,
+                                            "datatype": "Restriction",
+                                            "parent_id": 6583105,
+                                            "template_id": 6378211,
+                                            "updated_at": "2022-08-26T10:35:05.792+02:00"
+                                        },
+                                        {
+                                            "id": 6583111,
+                                            "name": "F60",
+                                            "code": null,
+                                            "description": null,
+                                            "datatype": "Restriction",
+                                            "parent_id": 6583105,
+                                            "template_id": 6378212,
+                                            "updated_at": "2022-08-26T10:35:05.797+02:00"
+                                        },
+                                        {
+                                            "id": 6583113,
+                                            "name": "ABC",
+                                            "code": null,
+                                            "description": null,
+                                            "datatype": "Restriction",
+                                            "parent_id": 6583105,
+                                            "template_id": 6378214,
+                                            "updated_at": "2022-08-26T10:35:05.802+02:00"
+                                        },
+                                        {
+                                            "id": 6583115,
+                                            "name": "70",
+                                            "code": null,
+                                            "description": null,
+                                            "datatype": "Restriction",
+                                            "parent_id": 6583105,
+                                            "template_id": 6378215,
+                                            "updated_at": "2022-08-26T10:35:05.807+02:00"
+                                        },
+                                        {
+                                            "id": 6583116,
+                                            "name": "F90",
+                                            "code": null,
+                                            "description": null,
+                                            "datatype": "Restriction",
+                                            "parent_id": 6583105,
+                                            "template_id": 6378213,
+                                            "updated_at": "2022-08-26T10:35:05.812+02:00"
+                                        }
+                                    ]
+                                },
+                                {
+                                    "id": 6583118,
+                                    "name": "Testeigenschaft",
+                                    "code": null,
+                                    "description": null,
+                                    "datatype": "Property",
+                                    "parent_id": 6583102,
+                                    "template_id": 6519792,
+                                    "updated_at": "2022-08-26T10:35:05.817+02:00",
+                                    "unit": "Kennzeichen",
+                                    "unit_reference": "Datatypes.IfcLabel",
+                                    "map_item_id": 3274994,
+                                    "map_item": "#.Testeigenschaft"
+                                },
+                                {
+                                    "id": 6583120,
+                                    "name": "Außenbauteil",
+                                    "code": null,
+                                    "description": null,
+                                    "datatype": "Property",
+                                    "parent_id": 6583102,
+                                    "template_id": 6378137,
+                                    "updated_at": "2022-08-26T10:35:05.822+02:00",
+                                    "unit": "Wahr/Falsch",
+                                    "unit_reference": "Datatypes.IfcBoolean",
+                                    "map_item_id": 3123893,
+                                    "map_item": "*.IsExternal"
+                                },
+                                {
+                                    "id": 6583121,
+                                    "name": "Tragendes Bauteil",
+                                    "code": null,
+                                    "description": null,
+                                    "datatype": "Property",
+                                    "parent_id": 6583102,
+                                    "template_id": 6378138,
+                                    "updated_at": "2022-08-26T10:35:05.830+02:00",
+                                    "unit": "Wahr/Falsch",
+                                    "unit_reference": "Datatypes.IfcBoolean",
+                                    "map_item_id": 3123900,
+                                    "map_item": "*.LoadBearing"
+                                },
+                                {
+                                    "id": 6583123,
+                                    "name": "Wärmedurchgangskoeffizient  (U-Wert)",
+                                    "code": null,
+                                    "description": null,
+                                    "datatype": "Property",
+                                    "parent_id": 6583102,
+                                    "template_id": 6378142,
+                                    "updated_at": "2022-08-26T10:35:05.834+02:00",
+                                    "unit": "Wärmedurchgängigkeit",
+                                    "unit_reference": "Measurements.IfcThermalTransmittanceMeasure",
+                                    "map_item_id": 3123948,
+                                    "map_item": "*.ThermalTransmittance"
+                                },
+                                {
+                                    "id": 6583124,
+                                    "name": "Bauteiltyp",
+                                    "code": null,
+                                    "description": null,
+                                    "datatype": "Property",
+                                    "parent_id": 6583102,
+                                    "template_id": 6378139,
+                                    "updated_at": "2022-08-26T10:35:05.839+02:00",
+                                    "unit": "Identifizierungszeichen",
+                                    "unit_reference": "Datatypes.IfcIdentifier",
+                                    "map_item_id": 3123945,
+                                    "map_item": "*.Reference"
+                                }
+                            ]
+                        },
+                        {
+                            "id": 6583126,
+                            "name": "TEST Properties",
+                            "code": null,
+                            "description": null,
+                            "datatype": "Group",
+                            "parent_id": 6583094,
+                            "template_id": 6378095,
+                            "updated_at": "2022-08-26T10:35:05.844+02:00",
+                            "child_concept": [
+                                {
+                                    "id": 6583127,
+                                    "name": "BreiteHöhe",
+                                    "code": null,
+                                    "description": null,
+                                    "datatype": "Property",
+                                    "parent_id": 6583126,
+                                    "template_id": 6378121,
+                                    "updated_at": "2022-08-26T10:35:05.849+02:00",
+                                    "unit": "Kennzeichen",
+                                    "unit_reference": "Datatypes.IfcLabel",
+                                    "map_item_id": 3124169,
+                                    "map_item": "#.BreiteHöhe"
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "id": 6583129,
+                    "name": "Innenwand nichttragend",
+                    "code": "2-02",
+                    "description": null,
+                    "datatype": "Type",
+                    "parent_id": 6583092,
+                    "template_id": 6378104,
+                    "updated_at": "2022-08-26T10:35:06.044+02:00",
+                    "map_item_id": 3123979,
+                    "map_item": "IfcWall.##.##.Pset_WallCommon.IsExternal:False Pset_WallCommon.LoadBearing:False",
+                    "child_concept": [
+                        {
+                            "id": 6583130,
+                            "name": "TEST Properties",
+                            "code": null,
+                            "description": null,
+                            "datatype": "Group",
+                            "parent_id": 6583129,
+                            "template_id": 6378095,
+                            "updated_at": "2022-08-26T10:35:06.061+02:00",
+                            "child_concept": [
+                                {
+                                    "id": 6583131,
+                                    "name": "AttTest",
+                                    "code": null,
+                                    "description": null,
+                                    "datatype": "Property",
+                                    "parent_id": 6583130,
+                                    "template_id": 6378122,
+                                    "updated_at": "2022-08-26T10:35:06.066+02:00",
+                                    "unit": "Kennzeichen",
+                                    "unit_reference": "Datatypes.IfcLabel",
+                                    "map_item_id": 3124175,
+                                    "map_item": "#.AttTest"
+                                }
+                            ]
+                        },
+                        {
+                            "id": 6583132,
+                            "name": "gemeinsame Eigenschaften",
+                            "code": "01",
+                            "description": null,
+                            "datatype": "Group",
+                            "parent_id": 6583129,
+                            "template_id": 6378108,
+                            "updated_at": "2022-08-26T10:35:06.071+02:00",
+                            "child_concept": [
+                                {
+                                    "id": 6583133,
+                                    "name": "Bauteiltyp",
+                                    "code": null,
+                                    "description": null,
+                                    "datatype": "Property",
+                                    "parent_id": 6583132,
+                                    "template_id": 6378139,
+                                    "updated_at": "2022-08-26T10:35:06.077+02:00",
+                                    "unit": "Identifizierungszeichen",
+                                    "unit_reference": "Datatypes.IfcIdentifier",
+                                    "map_item_id": 3123945,
+                                    "map_item": "*.Reference"
+                                },
+                                {
+                                    "id": 6583134,
+                                    "name": "Tragendes Bauteil",
+                                    "code": null,
+                                    "description": null,
+                                    "datatype": "Property",
+                                    "parent_id": 6583132,
+                                    "template_id": 6378138,
+                                    "updated_at": "2022-08-26T10:35:06.084+02:00",
+                                    "unit": "Wahr/Falsch",
+                                    "unit_reference": "Datatypes.IfcBoolean",
+                                    "map_item_id": 3123900,
+                                    "map_item": "*.LoadBearing"
+                                },
+                                {
+                                    "id": 6583135,
+                                    "name": "Testeigenschaft",
+                                    "code": null,
+                                    "description": null,
+                                    "datatype": "Property",
+                                    "parent_id": 6583132,
+                                    "template_id": 6519792,
+                                    "updated_at": "2022-08-26T10:35:06.106+02:00",
+                                    "unit": "Kennzeichen",
+                                    "unit_reference": "Datatypes.IfcLabel",
+                                    "map_item_id": 3274994,
+                                    "map_item": "#.Testeigenschaft"
+                                },
+                                {
+                                    "id": 6583136,
+                                    "name": "Feuerwiderstandsklasse",
+                                    "code": null,
+                                    "description": null,
+                                    "datatype": "Property",
+                                    "parent_id": 6583132,
+                                    "template_id": 6378140,
+                                    "updated_at": "2022-08-26T10:35:06.110+02:00",
+                                    "unit": "Kennzeichen",
+                                    "unit_reference": "Datatypes.IfcLabel",
+                                    "map_item_id": 3123946,
+                                    "map_item": "*.FireRating",
+                                    "child_concept": [
+                                        {
+                                            "id": 6583137,
+                                            "name": "F200",
+                                            "code": null,
+                                            "description": null,
+                                            "datatype": "Restriction",
+                                            "parent_id": 6583136,
+                                            "template_id": 6519793,
+                                            "updated_at": "2022-08-26T10:35:06.114+02:00"
+                                        },
+                                        {
+                                            "id": 6583138,
+                                            "name": "F60",
+                                            "code": null,
+                                            "description": null,
+                                            "datatype": "Restriction",
+                                            "parent_id": 6583136,
+                                            "template_id": 6378212,
+                                            "updated_at": "2022-08-26T10:35:06.117+02:00"
+                                        },
+                                        {
+                                            "id": 6583139,
+                                            "name": "ABC",
+                                            "code": null,
+                                            "description": null,
+                                            "datatype": "Restriction",
+                                            "parent_id": 6583136,
+                                            "template_id": 6378214,
+                                            "updated_at": "2022-08-26T10:35:06.121+02:00"
+                                        },
+                                        {
+                                            "id": 6583140,
+                                            "name": "F30",
+                                            "code": null,
+                                            "description": null,
+                                            "datatype": "Restriction",
+                                            "parent_id": 6583136,
+                                            "template_id": 6378211,
+                                            "updated_at": "2022-08-26T10:35:06.124+02:00"
+                                        },
+                                        {
+                                            "id": 6583141,
+                                            "name": "70",
+                                            "code": null,
+                                            "description": null,
+                                            "datatype": "Restriction",
+                                            "parent_id": 6583136,
+                                            "template_id": 6378215,
+                                            "updated_at": "2022-08-26T10:35:06.127+02:00"
+                                        },
+                                        {
+                                            "id": 6583142,
+                                            "name": "F90",
+                                            "code": null,
+                                            "description": null,
+                                            "datatype": "Restriction",
+                                            "parent_id": 6583136,
+                                            "template_id": 6378213,
+                                            "updated_at": "2022-08-26T10:35:06.130+02:00"
+                                        }
+                                    ]
+                                },
+                                {
+                                    "id": 6583143,
+                                    "name": "Außenbauteil",
+                                    "code": null,
+                                    "description": null,
+                                    "datatype": "Property",
+                                    "parent_id": 6583132,
+                                    "template_id": 6378137,
+                                    "updated_at": "2022-08-26T10:35:06.134+02:00",
+                                    "unit": "Wahr/Falsch",
+                                    "unit_reference": "Datatypes.IfcBoolean",
+                                    "map_item_id": 3123893,
+                                    "map_item": "*.IsExternal"
+                                },
+                                {
+                                    "id": 6583144,
+                                    "name": "Spannweite",
+                                    "code": null,
+                                    "description": null,
+                                    "datatype": "Property",
+                                    "parent_id": 6583132,
+                                    "template_id": 6378141,
+                                    "updated_at": "2022-08-26T10:35:06.138+02:00",
+                                    "unit": "Länge (positiv, \u003e0)",
+                                    "unit_reference": "Measurements.IfcPositiveLengthMeasure",
+                                    "map_item_id": 3123947,
+                                    "map_item": "*.Span"
+                                },
+                                {
+                                    "id": 6583145,
+                                    "name": "CKBauteiltyp",
+                                    "code": null,
+                                    "description": null,
+                                    "datatype": "Property",
+                                    "parent_id": 6583132,
+                                    "template_id": 6378307,
+                                    "updated_at": "2022-08-26T10:35:06.141+02:00",
+                                    "unit": "Kennzeichen",
+                                    "unit_reference": "Datatypes.IfcLabel"
+                                },
+                                {
+                                    "id": 6583146,
+                                    "name": "Wärmedurchgangskoeffizient  (U-Wert)",
+                                    "code": null,
+                                    "description": null,
+                                    "datatype": "Property",
+                                    "parent_id": 6583132,
+                                    "template_id": 6378142,
+                                    "updated_at": "2022-08-26T10:35:06.146+02:00",
+                                    "unit": "Wärmedurchgängigkeit",
+                                    "unit_reference": "Measurements.IfcThermalTransmittanceMeasure",
+                                    "map_item_id": 3123948,
+                                    "map_item": "*.ThermalTransmittance"
+                                }
+                            ]
+                        },
+                        {
+                            "id": 6583147,
+                            "name": "CKs Eigenschaften (Konzeptname!)",
+                            "code": null,
+                            "description": null,
+                            "datatype": "Group",
+                            "parent_id": 6583129,
+                            "template_id": 6378110,
+                            "updated_at": "2022-08-26T10:35:06.153+02:00",
+                            "map_item_id": 3123981,
+                            "map_item": "CKs Eigenschaften",
+                            "child_concept": [
+                                {
+                                    "id": 6583148,
+                                    "name": "Raumnummer",
+                                    "code": null,
+                                    "description": null,
+                                    "datatype": "Property",
+                                    "parent_id": 6583147,
+                                    "template_id": 6378150,
+                                    "updated_at": "2022-08-26T10:35:06.156+02:00",
+                                    "unit": "Kennzeichen",
+                                    "unit_reference": "Datatypes.IfcLabel",
+                                    "map_item_id": 3123977,
+                                    "map_item": "IfcElement Attributes.Name"
+                                },
+                                {
+                                    "id": 6583149,
+                                    "name": "Raumname",
+                                    "code": null,
+                                    "description": null,
+                                    "datatype": "Property",
+                                    "parent_id": 6583147,
+                                    "template_id": 6378149,
+                                    "updated_at": "2022-08-26T10:35:06.159+02:00",
+                                    "unit": "Kennzeichen",
+                                    "unit_reference": "Datatypes.IfcLabel",
+                                    "map_item_id": 3123976,
+                                    "map_item": "IfcSpatialElement Attributes.LongName"
+                                },
+                                {
+                                    "id": 6583150,
+                                    "name": "Test Bauteil",
+                                    "code": null,
+                                    "description": null,
+                                    "datatype": "Property",
+                                    "parent_id": 6583147,
+                                    "template_id": 6378146,
+                                    "updated_at": "2022-08-26T10:35:06.163+02:00",
+                                    "unit": "Wahr/Falsch",
+                                    "unit_reference": "Datatypes.IfcBoolean",
+                                    "map_item_id": 3123922,
+                                    "map_item": "#.Test Bauteil"
+                                },
+                                {
+                                    "id": 6583151,
+                                    "name": "CKsBeschreibung",
+                                    "code": null,
+                                    "description": null,
+                                    "datatype": "Property",
+                                    "parent_id": 6583147,
+                                    "template_id": 6378145,
+                                    "updated_at": "2022-08-26T10:35:06.166+02:00",
+                                    "unit": "Kennzeichen",
+                                    "unit_reference": "Datatypes.IfcLabel",
+                                    "map_item_id": 3123960,
+                                    "map_item": "IfcElement Attributes.Description"
+                                },
+                                {
+                                    "id": 6583152,
+                                    "name": "Testwert",
+                                    "code": null,
+                                    "description": null,
+                                    "datatype": "Property",
+                                    "parent_id": 6583147,
+                                    "template_id": 6378154,
+                                    "updated_at": "2022-08-26T10:35:06.169+02:00",
+                                    "unit": "Länge (nicht-negativ, \u003e=0).m",
+                                    "unit_reference": "Measurements.IfcNonNegativeLengthMeasure.METRE",
+                                    "map_item_id": 3124007,
+                                    "map_item": "#.Testwert"
+                                },
+                                {
+                                    "id": 6583153,
+                                    "name": "AttributName",
+                                    "code": null,
+                                    "description": null,
+                                    "datatype": "Property",
+                                    "parent_id": 6583147,
+                                    "template_id": 6378143,
+                                    "updated_at": "2022-08-26T10:35:06.172+02:00",
+                                    "unit": "Kennzeichen",
+                                    "unit_reference": "Datatypes.IfcLabel",
+                                    "map_item_id": 3123958,
+                                    "map_item": "IfcElement Attributes.Name"
+                                },
+                                {
+                                    "id": 6583154,
+                                    "name": "CKBauteiltyp",
+                                    "code": null,
+                                    "description": null,
+                                    "datatype": "Property",
+                                    "parent_id": 6583147,
+                                    "template_id": 6378144,
+                                    "updated_at": "2022-08-26T10:35:06.175+02:00",
+                                    "unit": "Kennzeichen",
+                                    "unit_reference": "Datatypes.IfcLabel",
+                                    "map_item_id": 3124009,
+                                    "map_item": "#.CKBauteiltyp"
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "id": 6583155,
+                    "name": "Decke",
+                    "code": null,
+                    "description": null,
+                    "datatype": "Group",
+                    "parent_id": 6583092,
+                    "template_id": 6378123,
+                    "updated_at": "2022-08-26T10:35:06.200+02:00",
+                    "child_concept": [
+                        {
+                            "id": 6583156,
+                            "name": "Tragende_Decken",
+                            "code": null,
+                            "description": null,
+                            "datatype": "Group",
+                            "parent_id": 6583155,
+                            "template_id": 6378163,
+                            "updated_at": "2022-08-26T10:35:06.210+02:00",
+                            "map_item_id": 3124122,
+                            "map_item": "Tragende_Decken",
+                            "child_concept": [
+                                {
+                                    "id": 6583157,
+                                    "name": "Stahlbetonelementdecke",
+                                    "code": null,
+                                    "description": null,
+                                    "datatype": "Type",
+                                    "parent_id": 6583156,
+                                    "template_id": 6378217,
+                                    "updated_at": "2022-08-26T10:35:06.216+02:00",
+                                    "map_item_id": 3124127,
+                                    "map_item": "IfcBuildingElementProxy"
+                                },
+                                {
+                                    "id": 6583158,
+                                    "name": "Stahlbetondecke",
+                                    "code": null,
+                                    "description": null,
+                                    "datatype": "Type",
+                                    "parent_id": 6583156,
+                                    "template_id": 6378216,
+                                    "updated_at": "2022-08-26T10:35:06.220+02:00",
+                                    "map_item_id": 3124123,
+                                    "map_item": "IfcBuildingElementProxy",
+                                    "child_concept": [
+                                        {
+                                            "id": 6583159,
+                                            "name": "TEST Properties",
+                                            "code": null,
+                                            "description": null,
+                                            "datatype": "Group",
+                                            "parent_id": 6583158,
+                                            "template_id": 6378095,
+                                            "updated_at": "2022-08-26T10:35:06.225+02:00",
+                                            "child_concept": [
+                                                {
+                                                    "id": 6583160,
+                                                    "name": "Test?Test",
+                                                    "code": null,
+                                                    "description": null,
+                                                    "datatype": "Property",
+                                                    "parent_id": 6583159,
+                                                    "template_id": 6378126,
+                                                    "updated_at": "2022-08-26T10:35:06.230+02:00",
+                                                    "unit": "Kennzeichen",
+                                                    "unit_reference": "Datatypes.IfcLabel",
+                                                    "map_item_id": 3124202,
+                                                    "map_item": "#.Test?Test"
+                                                }
+                                            ]
+                                        },
+                                        {
+                                            "id": 6583161,
+                                            "name": "Stahlbeton_Halbfertigteil_Fertigteil",
+                                            "code": null,
+                                            "description": null,
+                                            "datatype": "Group",
+                                            "parent_id": 6583158,
+                                            "template_id": 6378125,
+                                            "updated_at": "2022-08-26T10:35:06.235+02:00",
+                                            "child_concept": [
+                                                {
+                                                    "id": 6583162,
+                                                    "name": "zulaessige_Auflast_Elementdecke",
+                                                    "code": null,
+                                                    "description": null,
+                                                    "datatype": "Property",
+                                                    "parent_id": 6583161,
+                                                    "template_id": 6378171,
+                                                    "updated_at": "2022-08-26T10:35:06.241+02:00",
+                                                    "unit": "Kennzeichen",
+                                                    "unit_reference": "Datatypes.IfcLabel",
+                                                    "map_item_id": 3124186,
+                                                    "map_item": "#.zulaessige_Auflast_Elementdecke"
+                                                },
+                                                {
+                                                    "id": 6583163,
+                                                    "name": "Lichte_Weite_Elementdecke",
+                                                    "code": null,
+                                                    "description": null,
+                                                    "datatype": "Property",
+                                                    "parent_id": 6583161,
+                                                    "template_id": 6378170,
+                                                    "updated_at": "2022-08-26T10:35:06.269+02:00",
+                                                    "unit": "Kennzeichen",
+                                                    "unit_reference": "Datatypes.IfcLabel",
+                                                    "map_item_id": 3124181,
+                                                    "map_item": "#.Lichte_Weite_Elementdecke"
+                                                }
+                                            ]
+                                        },
+                                        {
+                                            "id": 6583164,
+                                            "name": "Stahlbeton",
+                                            "code": null,
+                                            "description": null,
+                                            "datatype": "Group",
+                                            "parent_id": 6583158,
+                                            "template_id": 6378124,
+                                            "updated_at": "2022-08-26T10:35:06.275+02:00",
+                                            "map_item_id": 3124133,
+                                            "map_item": "Stahlbeton",
+                                            "child_concept": [
+                                                {
+                                                    "id": 6583165,
+                                                    "name": "Unterstellungshoehe_STB",
+                                                    "code": null,
+                                                    "description": null,
+                                                    "datatype": "Property",
+                                                    "parent_id": 6583164,
+                                                    "template_id": 6378169,
+                                                    "updated_at": "2022-08-26T10:35:06.280+02:00",
+                                                    "unit": "Kennzeichen",
+                                                    "unit_reference": "Datatypes.IfcLabel",
+                                                    "map_item_id": 3124166,
+                                                    "map_item": "#.Unterstellungshoehe_STB"
+                                                },
+                                                {
+                                                    "id": 6583166,
+                                                    "name": "Bewehrungsgrad_kgm3",
+                                                    "code": null,
+                                                    "description": null,
+                                                    "datatype": "Property",
+                                                    "parent_id": 6583164,
+                                                    "template_id": 6378165,
+                                                    "updated_at": "2022-08-26T10:35:06.287+02:00",
+                                                    "unit": "Kennzeichen",
+                                                    "unit_reference": "Datatypes.IfcLabel",
+                                                    "map_item_id": 3124146,
+                                                    "map_item": "#.Bewehrungsgrad_kgm3"
+                                                },
+                                                {
+                                                    "id": 6583167,
+                                                    "name": "Funktion_Stahlbetonarbeiten",
+                                                    "code": null,
+                                                    "description": null,
+                                                    "datatype": "Property",
+                                                    "parent_id": 6583164,
+                                                    "template_id": 6378168,
+                                                    "updated_at": "2022-08-26T10:35:06.293+02:00",
+                                                    "unit": "Kennzeichen",
+                                                    "unit_reference": "Datatypes.IfcLabel",
+                                                    "map_item_id": 3124161,
+                                                    "map_item": "#.Funktion_Stahlbetonarbeiten"
+                                                },
+                                                {
+                                                    "id": 6583168,
+                                                    "name": "Betonkurzbezeichnung_(B1_B12)",
+                                                    "code": null,
+                                                    "description": null,
+                                                    "datatype": "Property",
+                                                    "parent_id": 6583164,
+                                                    "template_id": 6378164,
+                                                    "updated_at": "2022-08-26T10:35:06.308+02:00",
+                                                    "unit": "Kennzeichen",
+                                                    "unit_reference": "Datatypes.IfcLabel",
+                                                    "map_item_id": 3124141,
+                                                    "map_item": "#.Betonkurzbezeichnung_(B1_B12)"
+                                                },
+                                                {
+                                                    "id": 6583170,
+                                                    "name": "Expositionsklasse",
+                                                    "code": null,
+                                                    "description": null,
+                                                    "datatype": "Property",
+                                                    "parent_id": 6583164,
+                                                    "template_id": 6378167,
+                                                    "updated_at": "2022-08-26T10:35:06.315+02:00",
+                                                    "unit": "Kennzeichen",
+                                                    "unit_reference": "Datatypes.IfcLabel",
+                                                    "map_item_id": 3124156,
+                                                    "map_item": "Pset_ConcreteElementGeneral.ExposureClass"
+                                                },
+                                                {
+                                                    "id": 6583171,
+                                                    "name": "Druckfestigkeitsklasse_Beton",
+                                                    "code": null,
+                                                    "description": null,
+                                                    "datatype": "Property",
+                                                    "parent_id": 6583164,
+                                                    "template_id": 6378166,
+                                                    "updated_at": "2022-08-26T10:35:06.322+02:00",
+                                                    "unit": "Kennzeichen",
+                                                    "unit_reference": "Datatypes.IfcLabel",
+                                                    "map_item_id": 3124151,
+                                                    "map_item": "#.Druckfestigkeitsklasse_Beton"
+                                                }
+                                            ]
+                                        }
+                                    ]
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "id": 6583169,
+                    "name": "Geschoßdecke",
+                    "code": "2-04",
+                    "description": null,
+                    "datatype": "Type",
+                    "parent_id": 6583092,
+                    "template_id": 6378103,
+                    "updated_at": "2022-08-26T10:35:06.310+02:00",
+                    "map_item_id": 3309324,
+                    "map_item": "IfcSlab.##.##.Pset_SlabCommon.IsExternal:False",
+                    "child_concept": [
+                        {
+                            "id": 6583172,
+                            "name": "gemeinsame Eigenschaften",
+                            "code": "01",
+                            "description": null,
+                            "datatype": "Group",
+                            "parent_id": 6583169,
+                            "template_id": 6378108,
+                            "updated_at": "2022-08-26T10:35:06.329+02:00",
+                            "map_item_id": 3309326,
+                            "map_item": "Pset_SlabCommon",
+                            "child_concept": [
+                                {
+                                    "id": 6583173,
+                                    "name": "Tragendes Bauteil",
+                                    "code": null,
+                                    "description": null,
+                                    "datatype": "Property",
+                                    "parent_id": 6583172,
+                                    "template_id": 6378138,
+                                    "updated_at": "2022-08-26T10:35:06.343+02:00",
+                                    "unit": "Wahr/Falsch",
+                                    "unit_reference": "Datatypes.IfcBoolean",
+                                    "map_item_id": 3123900,
+                                    "map_item": "*.LoadBearing"
+                                },
+                                {
+                                    "id": 6583174,
+                                    "name": "Außenbauteil",
+                                    "code": null,
+                                    "description": null,
+                                    "datatype": "Property",
+                                    "parent_id": 6583172,
+                                    "template_id": 6378137,
+                                    "updated_at": "2022-08-26T10:35:06.356+02:00",
+                                    "unit": "Wahr/Falsch",
+                                    "unit_reference": "Datatypes.IfcBoolean",
+                                    "map_item_id": 3123893,
+                                    "map_item": "*.IsExternal"
+                                },
+                                {
+                                    "id": 6583175,
+                                    "name": "Bauteiltyp",
+                                    "code": null,
+                                    "description": null,
+                                    "datatype": "Property",
+                                    "parent_id": 6583172,
+                                    "template_id": 6378139,
+                                    "updated_at": "2022-08-26T10:35:06.367+02:00",
+                                    "unit": "Identifizierungszeichen",
+                                    "unit_reference": "Datatypes.IfcIdentifier",
+                                    "map_item_id": 3123945,
+                                    "map_item": "*.Reference"
+                                },
+                                {
+                                    "id": 6583176,
+                                    "name": "Testeigenschaft",
+                                    "code": null,
+                                    "description": null,
+                                    "datatype": "Property",
+                                    "parent_id": 6583172,
+                                    "template_id": 6519792,
+                                    "updated_at": "2022-08-26T10:35:06.396+02:00",
+                                    "unit": "Kennzeichen",
+                                    "unit_reference": "Datatypes.IfcLabel",
+                                    "map_item_id": 3274994,
+                                    "map_item": "#.Testeigenschaft"
+                                },
+                                {
+                                    "id": 6583177,
+                                    "name": "Feuerwiderstandsklasse",
+                                    "code": null,
+                                    "description": null,
+                                    "datatype": "Property",
+                                    "parent_id": 6583172,
+                                    "template_id": 6378140,
+                                    "updated_at": "2022-08-26T10:35:06.400+02:00",
+                                    "unit": "Kennzeichen",
+                                    "unit_reference": "Datatypes.IfcLabel",
+                                    "map_item_id": 3123946,
+                                    "map_item": "*.FireRating",
+                                    "child_concept": [
+                                        {
+                                            "id": 6583178,
+                                            "name": "F30",
+                                            "code": null,
+                                            "description": null,
+                                            "datatype": "Restriction",
+                                            "parent_id": 6583177,
+                                            "template_id": 6378211,
+                                            "updated_at": "2022-08-26T10:35:06.405+02:00"
+                                        },
+                                        {
+                                            "id": 6583179,
+                                            "name": "70",
+                                            "code": null,
+                                            "description": null,
+                                            "datatype": "Restriction",
+                                            "parent_id": 6583177,
+                                            "template_id": 6378215,
+                                            "updated_at": "2022-08-26T10:35:06.409+02:00"
+                                        },
+                                        {
+                                            "id": 6583180,
+                                            "name": "F60",
+                                            "code": null,
+                                            "description": null,
+                                            "datatype": "Restriction",
+                                            "parent_id": 6583177,
+                                            "template_id": 6378212,
+                                            "updated_at": "2022-08-26T10:35:06.413+02:00"
+                                        },
+                                        {
+                                            "id": 6583181,
+                                            "name": "F90",
+                                            "code": null,
+                                            "description": null,
+                                            "datatype": "Restriction",
+                                            "parent_id": 6583177,
+                                            "template_id": 6378213,
+                                            "updated_at": "2022-08-26T10:35:06.418+02:00"
+                                        },
+                                        {
+                                            "id": 6583182,
+                                            "name": "ABC",
+                                            "code": null,
+                                            "description": null,
+                                            "datatype": "Restriction",
+                                            "parent_id": 6583177,
+                                            "template_id": 6378214,
+                                            "updated_at": "2022-08-26T10:35:06.422+02:00"
+                                        },
+                                        {
+                                            "id": 6583183,
+                                            "name": "F200",
+                                            "code": null,
+                                            "description": null,
+                                            "datatype": "Restriction",
+                                            "parent_id": 6583177,
+                                            "template_id": 6519793,
+                                            "updated_at": "2022-08-26T10:35:06.426+02:00"
+                                        }
+                                    ]
+                                },
+                                {
+                                    "id": 6583185,
+                                    "name": "Spannweite",
+                                    "code": null,
+                                    "description": null,
+                                    "datatype": "Property",
+                                    "parent_id": 6583172,
+                                    "template_id": 6378141,
+                                    "updated_at": "2022-08-26T10:35:06.430+02:00",
+                                    "unit": "Länge (positiv, \u003e0)",
+                                    "unit_reference": "Measurements.IfcPositiveLengthMeasure",
+                                    "map_item_id": 3123947,
+                                    "map_item": "*.Span"
+                                },
+                                {
+                                    "id": 6583186,
+                                    "name": "Wärmedurchgangskoeffizient  (U-Wert)",
+                                    "code": null,
+                                    "description": null,
+                                    "datatype": "Property",
+                                    "parent_id": 6583172,
+                                    "template_id": 6378142,
+                                    "updated_at": "2022-08-26T10:35:06.434+02:00",
+                                    "unit": "Wärmedurchgängigkeit",
+                                    "unit_reference": "Measurements.IfcThermalTransmittanceMeasure",
+                                    "map_item_id": 3123948,
+                                    "map_item": "*.ThermalTransmittance"
+                                }
+                            ]
+                        },
+                        {
+                            "id": 6583188,
+                            "name": "CKs Eigenschaften (Konzeptname!)",
+                            "code": null,
+                            "description": null,
+                            "datatype": "Group",
+                            "parent_id": 6583169,
+                            "template_id": 6378110,
+                            "updated_at": "2022-08-26T10:35:06.441+02:00",
+                            "map_item_id": 3123981,
+                            "map_item": "CKs Eigenschaften",
+                            "child_concept": [
+                                {
+                                    "id": 6583199,
+                                    "name": "CKsBeschreibung",
+                                    "code": null,
+                                    "description": null,
+                                    "datatype": "Property",
+                                    "parent_id": 6583188,
+                                    "template_id": 6378145,
+                                    "updated_at": "2022-08-26T10:35:06.462+02:00",
+                                    "unit": "Kennzeichen",
+                                    "unit_reference": "Datatypes.IfcLabel",
+                                    "map_item_id": 3123960,
+                                    "map_item": "IfcElement Attributes.Description"
+                                },
+                                {
+                                    "id": 6583201,
+                                    "name": "Raumname",
+                                    "code": null,
+                                    "description": null,
+                                    "datatype": "Property",
+                                    "parent_id": 6583188,
+                                    "template_id": 6378149,
+                                    "updated_at": "2022-08-26T10:35:06.466+02:00",
+                                    "unit": "Kennzeichen",
+                                    "unit_reference": "Datatypes.IfcLabel",
+                                    "map_item_id": 3123976,
+                                    "map_item": "IfcSpatialElement Attributes.LongName"
+                                },
+                                {
+                                    "id": 6583203,
+                                    "name": "AttributName",
+                                    "code": null,
+                                    "description": null,
+                                    "datatype": "Property",
+                                    "parent_id": 6583188,
+                                    "template_id": 6378143,
+                                    "updated_at": "2022-08-26T10:35:06.469+02:00",
+                                    "unit": "Kennzeichen",
+                                    "unit_reference": "Datatypes.IfcLabel",
+                                    "map_item_id": 3123958,
+                                    "map_item": "IfcElement Attributes.Name"
+                                },
+                                {
+                                    "id": 6583204,
+                                    "name": "Testwert",
+                                    "code": null,
+                                    "description": null,
+                                    "datatype": "Property",
+                                    "parent_id": 6583188,
+                                    "template_id": 6378154,
+                                    "updated_at": "2022-08-26T10:35:06.474+02:00",
+                                    "unit": "Länge (nicht-negativ, \u003e=0).m",
+                                    "unit_reference": "Measurements.IfcNonNegativeLengthMeasure.METRE",
+                                    "map_item_id": 3124007,
+                                    "map_item": "#.Testwert"
+                                },
+                                {
+                                    "id": 6583189,
+                                    "name": "Raumnummer",
+                                    "code": null,
+                                    "description": null,
+                                    "datatype": "Property",
+                                    "parent_id": 6583188,
+                                    "template_id": 6378150,
+                                    "updated_at": "2022-08-26T10:35:06.444+02:00",
+                                    "unit": "Kennzeichen",
+                                    "unit_reference": "Datatypes.IfcLabel",
+                                    "map_item_id": 3123977,
+                                    "map_item": "IfcElement Attributes.Name"
+                                },
+                                {
+                                    "id": 6583192,
+                                    "name": "Test Bauteil",
+                                    "code": null,
+                                    "description": null,
+                                    "datatype": "Property",
+                                    "parent_id": 6583188,
+                                    "template_id": 6378146,
+                                    "updated_at": "2022-08-26T10:35:06.448+02:00",
+                                    "unit": "Wahr/Falsch",
+                                    "unit_reference": "Datatypes.IfcBoolean",
+                                    "map_item_id": 3123922,
+                                    "map_item": "#.Test Bauteil"
+                                },
+                                {
+                                    "id": 6583193,
+                                    "name": "CKBauteiltyp",
+                                    "code": null,
+                                    "description": null,
+                                    "datatype": "Property",
+                                    "parent_id": 6583188,
+                                    "template_id": 6378144,
+                                    "updated_at": "2022-08-26T10:35:06.452+02:00",
+                                    "unit": "Kennzeichen",
+                                    "unit_reference": "Datatypes.IfcLabel",
+                                    "map_item_id": 3124009,
+                                    "map_item": "#.CKBauteiltyp",
+                                    "child_concept": [
+                                        {
+                                            "id": 6583197,
+                                            "name": "Testwert",
+                                            "code": "1212",
+                                            "description": null,
+                                            "datatype": "Restriction",
+                                            "parent_id": 6583193,
+                                            "template_id": 6470184,
+                                            "updated_at": "2022-08-26T10:35:06.459+02:00"
+                                        }
+                                    ]
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "id": 6583184,
+                    "name": "Wand",
+                    "code": "1-01",
+                    "description": null,
+                    "datatype": "Type",
+                    "parent_id": 6583092,
+                    "template_id": 6378155,
+                    "updated_at": "2022-08-26T10:35:06.427+02:00",
+                    "map_item_id": 3124067,
+                    "map_item": "IfcWall",
+                    "child_concept": [
+                        {
+                            "id": 6583187,
+                            "name": "gemeinsame Eigenschaften",
+                            "code": "01",
+                            "description": null,
+                            "datatype": "Group",
+                            "parent_id": 6583184,
+                            "template_id": 6378108,
+                            "updated_at": "2022-08-26T10:35:06.440+02:00",
+                            "child_concept": [
+                                {
+                                    "id": 6583200,
+                                    "name": "Außenbauteil",
+                                    "code": null,
+                                    "description": null,
+                                    "datatype": "Property",
+                                    "parent_id": 6583187,
+                                    "template_id": 6378137,
+                                    "updated_at": "2022-08-26T10:35:06.464+02:00",
+                                    "unit": "Wahr/Falsch",
+                                    "unit_reference": "Datatypes.IfcBoolean",
+                                    "map_item_id": 3123893,
+                                    "map_item": "*.IsExternal"
+                                },
+                                {
+                                    "id": 6583207,
+                                    "name": "Testeigenschaft",
+                                    "code": null,
+                                    "description": null,
+                                    "datatype": "Property",
+                                    "parent_id": 6583187,
+                                    "template_id": 6519792,
+                                    "updated_at": "2022-08-26T10:35:06.486+02:00",
+                                    "unit": "Kennzeichen",
+                                    "unit_reference": "Datatypes.IfcLabel",
+                                    "map_item_id": 3274994,
+                                    "map_item": "#.Testeigenschaft"
+                                },
+                                {
+                                    "id": 6583209,
+                                    "name": "Tragendes Bauteil",
+                                    "code": null,
+                                    "description": null,
+                                    "datatype": "Property",
+                                    "parent_id": 6583187,
+                                    "template_id": 6378138,
+                                    "updated_at": "2022-08-26T10:35:06.493+02:00",
+                                    "unit": "Wahr/Falsch",
+                                    "unit_reference": "Datatypes.IfcBoolean",
+                                    "map_item_id": 3123900,
+                                    "map_item": "*.LoadBearing"
+                                },
+                                {
+                                    "id": 6583213,
+                                    "name": "Feuerwiderstandsklasse",
+                                    "code": null,
+                                    "description": null,
+                                    "datatype": "Property",
+                                    "parent_id": 6583187,
+                                    "template_id": 6378140,
+                                    "updated_at": "2022-08-26T10:35:06.505+02:00",
+                                    "unit": "Kennzeichen",
+                                    "unit_reference": "Datatypes.IfcLabel",
+                                    "map_item_id": 3123946,
+                                    "map_item": "*.FireRating",
+                                    "child_concept": [
+                                        {
+                                            "id": 6583216,
+                                            "name": "F90",
+                                            "code": null,
+                                            "description": null,
+                                            "datatype": "Restriction",
+                                            "parent_id": 6583213,
+                                            "template_id": 6378213,
+                                            "updated_at": "2022-08-26T10:35:06.513+02:00"
+                                        },
+                                        {
+                                            "id": 6583218,
+                                            "name": "70",
+                                            "code": null,
+                                            "description": null,
+                                            "datatype": "Restriction",
+                                            "parent_id": 6583213,
+                                            "template_id": 6378215,
+                                            "updated_at": "2022-08-26T10:35:06.518+02:00"
+                                        },
+                                        {
+                                            "id": 6583220,
+                                            "name": "F200",
+                                            "code": null,
+                                            "description": null,
+                                            "datatype": "Restriction",
+                                            "parent_id": 6583213,
+                                            "template_id": 6519793,
+                                            "updated_at": "2022-08-26T10:35:06.523+02:00"
+                                        },
+                                        {
+                                            "id": 6583222,
+                                            "name": "ABC",
+                                            "code": null,
+                                            "description": null,
+                                            "datatype": "Restriction",
+                                            "parent_id": 6583213,
+                                            "template_id": 6378214,
+                                            "updated_at": "2022-08-26T10:35:06.528+02:00"
+                                        },
+                                        {
+                                            "id": 6583224,
+                                            "name": "F60",
+                                            "code": null,
+                                            "description": null,
+                                            "datatype": "Restriction",
+                                            "parent_id": 6583213,
+                                            "template_id": 6378212,
+                                            "updated_at": "2022-08-26T10:35:06.532+02:00"
+                                        },
+                                        {
+                                            "id": 6583226,
+                                            "name": "F30",
+                                            "code": null,
+                                            "description": null,
+                                            "datatype": "Restriction",
+                                            "parent_id": 6583213,
+                                            "template_id": 6378211,
+                                            "updated_at": "2022-08-26T10:35:06.537+02:00"
+                                        }
+                                    ]
+                                },
+                                {
+                                    "id": 6583191,
+                                    "name": "Wärmedurchgangskoeffizient  (U-Wert)",
+                                    "code": null,
+                                    "description": null,
+                                    "datatype": "Property",
+                                    "parent_id": 6583187,
+                                    "template_id": 6378142,
+                                    "updated_at": "2022-08-26T10:35:06.447+02:00",
+                                    "unit": "Wärmedurchgängigkeit",
+                                    "unit_reference": "Measurements.IfcThermalTransmittanceMeasure",
+                                    "map_item_id": 3123948,
+                                    "map_item": "*.ThermalTransmittance"
+                                },
+                                {
+                                    "id": 6583194,
+                                    "name": "Spannweite",
+                                    "code": null,
+                                    "description": null,
+                                    "datatype": "Property",
+                                    "parent_id": 6583187,
+                                    "template_id": 6378141,
+                                    "updated_at": "2022-08-26T10:35:06.455+02:00",
+                                    "unit": "Länge (positiv, \u003e0)",
+                                    "unit_reference": "Measurements.IfcPositiveLengthMeasure",
+                                    "map_item_id": 3123947,
+                                    "map_item": "*.Span"
+                                },
+                                {
+                                    "id": 6583196,
+                                    "name": "Bauteiltyp",
+                                    "code": null,
+                                    "description": null,
+                                    "datatype": "Property",
+                                    "parent_id": 6583187,
+                                    "template_id": 6378139,
+                                    "updated_at": "2022-08-26T10:35:06.458+02:00",
+                                    "unit": "Identifizierungszeichen",
+                                    "unit_reference": "Datatypes.IfcIdentifier",
+                                    "map_item_id": 3123945,
+                                    "map_item": "*.Reference"
+                                }
+                            ]
+                        }
+                    ]
+                }
+            ]
         }
     ]
 }


### PR DESCRIPTION
## What

- BIMQ 2.9 adds information about the actor for concepts of type `property` and `geometry` for the endpoint `get_concept_tree`. The example file is updated accordingly.
- The example file for `get_concept_tree` missed some fields: `code`, `unit`, `unit_reference`